### PR TITLE
Add workspace management with automatic Makefile discovery

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -78,12 +78,6 @@
 - Detect and syntax-highlight embedded languages (bash, python, etc.) in targets
 - Inspired by Just's ability to write recipes in any language
 
-#### 7. Workspace/Project Management
-- Quick switching between different project Makefiles
-- Show in status bar what makefile is using now
-- Remember last-used targets per project
-- Support monorepo scenarios
-
 #### 8. CI/CD Preview
 - Show which targets would run in CI
 - Simulate CI environment locally
@@ -110,6 +104,23 @@
 - Export execution results to JSON/log files
 - Shell integration for command history (bash, zsh)
 - **Implementation complete**: Both JSON and log export formats with configurable rotation, shell history integration with file locking for bash and zsh
+
+#### ✅ 7. Workspace/Project Management
+- Quick switching between different project Makefiles with press 'w'
+- Automatic discovery: Scans project tree (3 levels deep) to find all Makefiles automatically
+- Recent workspace list: Last 10 accessed Makefiles with "time ago" display and access count
+- Discovered workspaces: Shows newly found Makefiles in project that haven't been used yet
+- Favorite workspaces: Star frequently used projects (press 'f' to toggle)
+- Status bar integration: Shows current Makefile path (relative to cwd)
+- Per-project history: Already supported via feature #3 (each Makefile has its own execution history)
+- Monorepo support: Discovery navigates directory trees with smart exclusions
+- Smart exclusions: Skips `.git`, `node_modules`, `vendor`, `build`, `dist`, `.cache`, etc.
+- Access tracking: Records access count and last accessed time for each workspace
+- Persistent storage: Workspace data saved in `~/.cache/lazymake/workspaces.json`
+- Smart Makefile detection: Supports Makefile, makefile, GNUmakefile, *.mk, *.mak patterns
+- Automatic cleanup: Removes workspace entries for deleted Makefiles
+- Fast scanning: 5-second timeout ensures responsiveness in large projects
+- **Implementation complete**: Full workspace management with automatic discovery, recent list, favorites, and seamless switching
 
 ### Research Sources
 - [Makefile Success Stories from Open Source Projects](https://moldstud.com/articles/p-unlocking-makefiles-success-stories-from-leading-open-source-projects)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A beautiful terminal user interface for browsing and executing Makefile targets.
 - [Writing Self-Documenting Makefiles](#writing-self-documenting-makefiles)
 - [Recent History & Smart Navigation](#recent-history--smart-navigation)
 - [Variable Inspector: Understanding Your Build Configuration](#variable-inspector-understanding-your-build-configuration)
+- [Workspace Management: Working with Multiple Projects](#workspace-management-working-with-multiple-projects)
 - [Understanding Dependency Graphs](#understanding-dependency-graphs)
 - [Safety Features: Preventing Accidental Disasters](#safety-features-preventing-accidental-disasters)
   - [Visual Indicators](#visual-indicators)
@@ -94,6 +95,19 @@ Make dominates build automation with 19% presence in top GitHub repos, but devel
   - Dual display: Shows both raw values and fully expanded values
   - Smart navigation: Scrollable list with up/down or j/k keys
 
+- **Workspace/Project Management**: Quick switching between different projects
+  - Press `w` to open workspace picker with recent and discovered Makefiles
+  - Automatic discovery: Scans project tree (3 levels deep) to find all Makefiles
+  - Recent workspaces: Last 10 accessed Makefiles with "time ago" display and access count
+  - Discovered workspaces: Shows newly found Makefiles in project that haven't been used yet
+  - Favorite workspaces: Star frequently used projects (press `f` to toggle favorites)
+  - Status bar integration: Shows current Makefile path relative to working directory
+  - Per-project history: Each Makefile maintains its own execution history
+  - Smart exclusions: Skips `.git`, `node_modules`, `vendor`, build directories automatically
+  - Access tracking: Records access count and last accessed time per workspace
+  - Persistent storage: Workspace data saved in `~/.cache/lazymake/workspaces.json`
+  - Automatic cleanup: Removes workspace entries for deleted Makefiles
+
 ### Planned
 
 #### High Priority
@@ -101,7 +115,6 @@ Make dominates build automation with 19% presence in top GitHub repos, but devel
 
 ### Nice to Have
 - Multi-language recipe support with syntax highlighting
-- Workspace/project management for monorepos
 - Variable runtime overrides through TUI
 - Watch mode and CI/CD integration
 
@@ -163,6 +176,7 @@ lazymake -t <theme-name>
 - `Enter` - Execute selected target
 - `g` - View dependency graph for selected target
 - `v` - View variable inspector
+- `w` - Open workspace picker to switch between Makefiles
 - `?` - Toggle help view
 - `/` - Filter/search targets
 - `q` or `ctrl+c` - Quit
@@ -184,6 +198,13 @@ lazymake -t <theme-name>
 #### Output View
 - `↑/↓` or `j/k` - Scroll through output
 - `esc` - Return to list view
+- `q` or `ctrl+c` - Quit
+
+#### Workspace Picker
+- `↑/↓` or `j/k` - Navigate workspace list
+- `Enter` - Switch to selected workspace
+- `f` - Toggle favorite for selected workspace
+- `esc` or `w` - Return to list view
 - `q` or `ctrl+c` - Quit
 
 Configuration can be set via `.lazymake.yaml` in your project directory.
@@ -383,6 +404,151 @@ clean: ## Clean build artifacts
 - **`↑/↓` or `j/k`**: Navigate between variables
 - **`v` or `esc`**: Return to list view
 - **Auto-scroll**: Inspector automatically scrolls to keep selected variable visible
+
+## Workspace Management: Working with Multiple Projects
+
+lazymake makes it easy to work with multiple projects and Makefiles. Press `w` to see recent workspaces and automatically discovered Makefiles in your project.
+
+### Workspace Picker (Press `w`)
+
+Access recent and discovered Makefiles with a single keypress:
+
+```
+┌─ Switch Workspace ────────────────────────────────────────┐
+│                                                            │
+│ ⭐ ./Makefile                                              │
+│    Last used: 2 minutes ago • 15 times                    │
+│                                                            │
+│    ../other-project/Makefile                              │
+│    Last used: 1 hour ago • 8 times                        │
+│                                                            │
+│    examples/dangerous.mk                                  │
+│    Discovered in project                                  │
+│                                                            │
+│    tools/Makefile                                         │
+│    Discovered in project                                  │
+│                                                            │
+└────────────────────────────────────────────────────────────┘
+  2 recent • 2 discovered
+  enter: switch • f: favorite • esc/w: cancel
+```
+
+**Features:**
+- **Automatic discovery**: Scans your project tree (up to 3 levels deep) to find all Makefiles
+- **Recent workspaces**: Shows last 10 accessed Makefiles with access tracking
+- **Discovered workspaces**: Displays found Makefiles you haven't used yet
+- **Favorites first**: Star frequently used projects with `f` - they appear at the top
+- **Access tracking**: Displays "time ago" (e.g., "2 hours ago") and access count for recent workspaces
+- **Smart exclusions**: Skips `.git`, `node_modules`, `vendor`, build directories, and other common non-code paths
+- **Fast scanning**: 5-second timeout ensures responsiveness even in large projects
+
+### Status Bar Integration
+
+The current workspace is always visible in the status bar:
+
+```
+└──────────────────────────────────────────────────────────┘
+│ ./Makefile • 12 targets • 2 dangerous    enter: run • q │
+└──────────────────────────────────────────────────────────┘
+```
+
+The path is displayed relative to your current working directory:
+- `./Makefile` - in current directory
+- `../other/Makefile` - in sibling directory
+- `~/projects/foo/Makefile` - absolute path with `~` expansion
+
+### Per-Project History
+
+Each workspace automatically maintains its own execution history. When you switch between projects, you'll see the recent targets for that specific Makefile:
+
+```
+# Working in project A
+RECENT
+⏱  build-api    Build the API server       3.2s
+⏱  test-api     Run API tests              1.5s
+
+# Switch to project B (press 'w')
+RECENT
+⏱  deploy-prod  Deploy to production       45.1s
+⏱  build-web    Build web frontend         8.3s
+```
+
+This means:
+- Each Makefile remembers its own frequently used targets
+- No need to scroll through unrelated targets
+- Faster context switching between projects
+
+### Automatic Tracking
+
+lazymake automatically tracks workspace usage:
+- **On first use**: Creates workspace entry when you run a target
+- **On subsequent uses**: Updates access count and last accessed time
+- **On cleanup**: Removes entries for deleted Makefiles automatically
+- **Persistent**: Data survives across sessions in `~/.cache/lazymake/workspaces.json`
+
+### How Discovery Works
+
+When you press `w`, lazymake:
+1. **Records current Makefile** - Ensures your current file appears in the list
+2. **Scans project tree** - Searches up to 3 levels deep from current directory
+3. **Finds all Makefiles** - Detects `Makefile`, `makefile`, `GNUmakefile`, `*.mk`, `*.mak`
+4. **Applies exclusions** - Skips `.git`, `node_modules`, `vendor`, `build`, `dist`, `.cache`, etc.
+5. **Combines results** - Shows recent workspaces first, then newly discovered ones
+6. **Fast operation** - 5-second timeout prevents hanging on large projects
+
+### Use Cases
+
+#### 1. Monorepo Development
+
+Working with multiple Makefiles in a large repository:
+
+```
+my-monorepo/
+├── Makefile              # Root Makefile
+├── services/
+│   ├── api/Makefile      # API service
+│   ├── auth/Makefile     # Auth service
+│   └── worker/Makefile   # Background worker
+└── frontend/Makefile     # Frontend app
+```
+
+Press `w` to see all Makefiles automatically - no manual browsing needed!
+
+#### 2. Multi-Project Development
+
+Switching between different projects:
+- Press `w` to see recent projects and discovered Makefiles
+- Star your most frequently used projects with `f`
+- Favorites always appear at the top of the list
+
+#### 3. Onboarding
+
+New to a project? Press `w`:
+- Instantly see all available Makefiles
+- Discovered Makefiles show "Discovered in project"
+- Select one to start working - it gets added to your recent list
+
+### For Makefiles Outside Discovery Range
+
+If you need a Makefile that's:
+- More than 3 levels deep
+- In an excluded directory
+- Outside your current project
+
+Use the CLI flag:
+```bash
+lazymake -f path/to/Makefile
+```
+
+Once accessed, it appears in your recent workspaces list.
+
+### Navigation
+
+- **`w`**: Open workspace picker from list view
+- **`↑/↓` or `j/k`**: Navigate workspaces
+- **`f`**: Toggle favorite (star/unstar workspace)
+- **`enter`**: Switch to selected workspace
+- **`esc` or `w`**: Return to main list view
 
 ## Understanding Dependency Graphs
 

--- a/cmd/lazymake/main.go
+++ b/cmd/lazymake/main.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/rshelekhov/lazymake/config"
 	"github.com/rshelekhov/lazymake/internal/tui"
+	"github.com/rshelekhov/lazymake/internal/workspace"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -38,7 +39,16 @@ func run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Initialize workspace manager
+	workspaceMgr, err := workspace.Load()
+	if err != nil {
+		// Graceful degradation: continue with empty workspace manager
+		workspaceMgr = workspace.NewEmpty()
+	}
+
 	m := tui.NewModel(cfg)
+	m.WorkspaceManager = workspaceMgr
+
 	p := tea.NewProgram(m, tea.WithAltScreen())
 
 	if _, err := p.Run(); err != nil {

--- a/internal/export/record.go
+++ b/internal/export/record.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/rshelekhov/lazymake/internal/executor"
+	"github.com/rshelekhov/lazymake/version"
 )
 
 // ExecutionRecord represents a complete execution result for export
@@ -71,7 +72,7 @@ func NewExecutionRecord(makefilePath, targetName string, result executor.Result)
 		WorkingDir:      workingDir,
 		User:            currentUser,
 		Hostname:        hostname,
-		LazymakeVersion: "0.3.0", // TODO: Get from version constant
+		LazymakeVersion: version.Version,
 	}
 }
 

--- a/internal/tui/delegate_workspace.go
+++ b/internal/tui/delegate_workspace.go
@@ -1,0 +1,120 @@
+package tui
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/rshelekhov/lazymake/internal/workspace"
+)
+
+// WorkspaceItem implements list.Item for workspace picker
+type WorkspaceItem struct {
+	Workspace workspace.Workspace
+	RelPath   string // Relative path for display
+}
+
+// FilterValue returns the string value to filter against
+func (w WorkspaceItem) FilterValue() string {
+	return w.Workspace.Path
+}
+
+// WorkspaceItemDelegate is a custom delegate for rendering workspace list items
+type WorkspaceItemDelegate struct{}
+
+func (d WorkspaceItemDelegate) Height() int  { return 2 }
+func (d WorkspaceItemDelegate) Spacing() int { return 1 }
+func (d WorkspaceItemDelegate) Update(msg tea.Msg, m *list.Model) tea.Cmd {
+	return nil
+}
+
+func (d WorkspaceItemDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) {
+	ws, ok := item.(WorkspaceItem)
+	if !ok {
+		return
+	}
+
+	// Determine if this item is selected
+	isSelected := index == m.Index()
+
+	// Line 1: Favorite indicator + path
+	var prefix string
+	if ws.Workspace.IsFavorite {
+		prefix = "⭐ "
+	} else {
+		prefix = "   "
+	}
+
+	// Style the path
+	pathStyle := lipgloss.NewStyle().Foreground(PrimaryColor)
+	if isSelected {
+		pathStyle = pathStyle.Bold(true)
+	}
+
+	line1 := pathStyle.Render(prefix + ws.RelPath)
+
+	// Line 2: Metadata (last accessed time, access count)
+	metaStyle := lipgloss.NewStyle().Foreground(MutedColor)
+
+	var line2 string
+	if ws.Workspace.AccessCount > 0 {
+		// Recently accessed workspace - show access info
+		timeAgo := formatTimeAgo(ws.Workspace.LastAccessed)
+		accessInfo := fmt.Sprintf("%d times", ws.Workspace.AccessCount)
+		line2 = metaStyle.Render(fmt.Sprintf("   Last used: %s • %s", timeAgo, accessInfo))
+	} else {
+		// Discovered but never accessed - show "discovered" label
+		line2 = metaStyle.Render("   Discovered in project")
+	}
+
+	fmt.Fprintf(w, "%s\n%s", line1, line2)
+}
+
+// formatTimeAgo formats a timestamp as a human-readable "time ago" string
+func formatTimeAgo(t time.Time) string {
+	duration := time.Since(t)
+
+	switch {
+	case duration < time.Minute:
+		return "just now"
+	case duration < time.Hour:
+		minutes := int(duration.Minutes())
+		if minutes == 1 {
+			return "1 minute ago"
+		}
+		return fmt.Sprintf("%d minutes ago", minutes)
+	case duration < 24*time.Hour:
+		hours := int(duration.Hours())
+		if hours == 1 {
+			return "1 hour ago"
+		}
+		return fmt.Sprintf("%d hours ago", hours)
+	case duration < 7*24*time.Hour:
+		days := int(duration.Hours() / 24)
+		if days == 1 {
+			return "1 day ago"
+		}
+		return fmt.Sprintf("%d days ago", days)
+	case duration < 30*24*time.Hour:
+		weeks := int(duration.Hours() / 24 / 7)
+		if weeks == 1 {
+			return "1 week ago"
+		}
+		return fmt.Sprintf("%d weeks ago", weeks)
+	case duration < 365*24*time.Hour:
+		months := int(duration.Hours() / 24 / 30)
+		if months == 1 {
+			return "1 month ago"
+		}
+		return fmt.Sprintf("%d months ago", months)
+	default:
+		years := int(duration.Hours() / 24 / 365)
+		if years == 1 {
+			return "1 year ago"
+		}
+		return fmt.Sprintf("%d years ago", years)
+	}
+}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -37,6 +37,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateExecuting(msg)
 	case StateVariables:
 		return m.updateVariables(msg)
+	case StateWorkspace:
+		return m.updateWorkspace(msg)
 	default:
 		return m, nil
 	}
@@ -72,6 +74,12 @@ func (m Model) updateList(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Toggle variable inspector view
 			m.State = StateVariables
 			m.VariableListIndex = 0
+			return m, nil
+
+		case "w":
+			// Open workspace picker
+			m.State = StateWorkspace
+			m.initWorkspacePicker()
 			return m, nil
 
 		case "g":

--- a/internal/tui/update_workspace.go
+++ b/internal/tui/update_workspace.go
@@ -1,0 +1,227 @@
+package tui
+
+import (
+	"os"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/rshelekhov/lazymake/config"
+	"github.com/rshelekhov/lazymake/internal/workspace"
+)
+
+// workspaceSwitchedMsg is sent when workspace switch completes
+type workspaceSwitchedMsg struct {
+	newModel Model
+	err      error
+}
+
+// updateWorkspace handles updates when in workspace picker state
+func (m Model) updateWorkspace(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+
+	case workspaceSwitchedMsg:
+		// Workspace switch completed
+		if msg.err != nil {
+			// Switch failed - show error and return to list
+			m.Err = msg.err
+			m.State = StateList
+			return m, nil
+		}
+		// Replace entire model with new model
+		return msg.newModel, nil
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q", "ctrl+c":
+			return m, tea.Quit
+
+		case "esc", "w":
+			// Cancel and return to list view
+			m.State = StateList
+			return m, nil
+
+		case "f":
+			// Toggle favorite
+			return m.handleToggleFavorite()
+
+		case "enter":
+			// Switch to selected workspace
+			return m.handleWorkspaceSelection()
+		}
+
+	case tea.WindowSizeMsg:
+		m.Width = msg.Width
+		m.Height = msg.Height
+
+		// Calculate workspace list size (similar to main list)
+		listWidth := msg.Width - 4
+		listHeight := msg.Height - 6 // Account for title and status bar
+
+		m.WorkspaceList.SetSize(listWidth, listHeight)
+	}
+
+	// Delegate to workspace list for navigation
+	var cmd tea.Cmd
+	m.WorkspaceList, cmd = m.WorkspaceList.Update(msg)
+
+	return m, cmd
+}
+
+// handleWorkspaceSelection processes workspace selection and initiates switch
+func (m Model) handleWorkspaceSelection() (Model, tea.Cmd) {
+	selected := m.WorkspaceList.SelectedItem()
+	if ws, ok := selected.(WorkspaceItem); ok {
+		// Load config to get current settings
+		cfg, err := config.Load()
+		if err != nil {
+			// Config load failed - show error
+			m.Err = err
+			m.State = StateList
+			return m, nil
+		}
+
+		// Trigger workspace switch
+		return m, switchWorkspaceCmd(ws.Workspace.Path, cfg, m)
+	}
+	return m, nil
+}
+
+// handleToggleFavorite toggles favorite status for selected workspace
+func (m Model) handleToggleFavorite() (Model, tea.Cmd) {
+	selected := m.WorkspaceList.SelectedItem()
+	if ws, ok := selected.(WorkspaceItem); ok {
+		if m.WorkspaceManager != nil {
+			m.WorkspaceManager.ToggleFavorite(ws.Workspace.Path)
+			_ = m.WorkspaceManager.Save()
+
+			// Refresh workspace list to show updated favorite status
+			m.refreshWorkspaceList()
+		}
+	}
+	return m, nil
+}
+
+// switchWorkspaceCmd performs the workspace switch asynchronously
+func switchWorkspaceCmd(newPath string, cfg *config.Config, oldModel Model) tea.Cmd {
+	return func() tea.Msg {
+		// Create new model with new Makefile
+		newModel := oldModel.SwitchWorkspace(newPath, cfg)
+
+		// Return to list state after switch
+		newModel.State = StateList
+
+		return workspaceSwitchedMsg{
+			newModel: newModel,
+			err:      nil,
+		}
+	}
+}
+
+// initWorkspacePicker initializes the workspace picker list
+func (m *Model) initWorkspacePicker() {
+	if m.WorkspaceManager == nil {
+		return
+	}
+
+	// Record current Makefile as accessed (ensures it appears in the list)
+	m.WorkspaceManager.RecordAccess(m.MakefilePath)
+	_ = m.WorkspaceManager.Save() // Async save, ignore errors (non-critical)
+
+	cwd, _ := os.Getwd()
+
+	// Discover Makefiles in the project (starting from cwd or Makefile directory)
+	searchRoot := cwd
+	if searchRoot == "" {
+		searchRoot = "."
+	}
+
+	discovered, err := workspace.DiscoverMakefiles(searchRoot, workspace.DefaultDiscoveryOptions())
+	if err != nil {
+		// Fall back to recent-only if discovery fails
+		discovered = []workspace.DiscoveryResult{}
+	}
+
+	// Build a map of all discovered Makefiles by path
+	discoveredMap := make(map[string]workspace.DiscoveryResult)
+	for _, result := range discovered {
+		discoveredMap[result.Path] = result
+	}
+
+	// Get recent workspaces
+	recent := m.WorkspaceManager.GetRecent(10)
+
+	// Build combined list: recent first, then discovered (excluding duplicates)
+	var items []list.Item
+
+	// Add recent workspaces first
+	recentPaths := make(map[string]bool)
+	for _, ws := range recent {
+		relPath := m.WorkspaceManager.GetRelativePath(ws.Path, cwd)
+		items = append(items, WorkspaceItem{
+			Workspace: ws,
+			RelPath:   relPath,
+		})
+		recentPaths[ws.Path] = true
+	}
+
+	// Add discovered Makefiles that aren't already in recent
+	for _, result := range discovered {
+		if !recentPaths[result.Path] {
+			// Create a workspace entry for discovered Makefile
+			ws := workspace.Workspace{
+				Path:         result.Path,
+				LastAccessed: result.ModTime,
+				AccessCount:  0,
+				IsFavorite:   false,
+			}
+			relPath := m.WorkspaceManager.GetRelativePath(result.Path, cwd)
+			items = append(items, WorkspaceItem{
+				Workspace: ws,
+				RelPath:   relPath,
+			})
+		}
+	}
+
+	// Create list with workspace delegate
+	delegate := WorkspaceItemDelegate{}
+	l := list.New(items, delegate, 0, 0)
+	l.Title = "" // Don't show title - we render it manually in the view
+	l.SetShowStatusBar(false)
+	l.SetShowHelp(false)
+	l.SetFilteringEnabled(true)
+	l.Styles.Title = TitleStyle
+
+	// Set list size based on current dimensions
+	listWidth := m.Width - 4
+	listHeight := m.Height - 6
+	l.SetSize(listWidth, listHeight)
+
+	m.WorkspaceList = l
+}
+
+// refreshWorkspaceList refreshes the workspace list items (e.g., after toggling favorite)
+func (m *Model) refreshWorkspaceList() {
+	if m.WorkspaceManager == nil {
+		return
+	}
+
+	// Get recent workspaces
+	recent := m.WorkspaceManager.GetRecent(10)
+
+	// Convert to list items
+	items := make([]list.Item, len(recent))
+	cwd, _ := os.Getwd()
+	for i, ws := range recent {
+		// Compute relative path for display
+		relPath := m.WorkspaceManager.GetRelativePath(ws.Path, cwd)
+
+		items[i] = WorkspaceItem{
+			Workspace: ws,
+			RelPath:   relPath,
+		}
+	}
+
+	// Update list items
+	m.WorkspaceList.SetItems(items)
+}
+

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -29,6 +29,8 @@ func (m Model) View() string {
 		return m.renderConfirmView()
 	case StateVariables:
 		return m.renderVariablesView()
+	case StateWorkspace:
+		return m.renderWorkspaceView()
 	case StateList:
 		return m.renderListView()
 	default:

--- a/internal/tui/view_list.go
+++ b/internal/tui/view_list.go
@@ -2,6 +2,8 @@ package tui
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -299,8 +301,9 @@ func (m Model) renderStatusBar() string {
 		}
 	}
 
-	// Left side: stats
-	leftStats := []string{fmt.Sprintf("%d targets", totalTargets)}
+	// Left side: workspace path + stats
+	workspacePath := m.getWorkspaceDisplayPath()
+	leftStats := []string{workspacePath, fmt.Sprintf("%d targets", totalTargets)}
 
 	if dangerousCount > 0 {
 		leftStats = append(leftStats, fmt.Sprintf("%d dangerous", dangerousCount))
@@ -492,4 +495,23 @@ func renderVariablesSection(vars []string) string {
 	util.WriteString(&builder, hintStyle.Render("    💡 Press 'v' to view all variables")+"\n")
 
 	return builder.String()
+}
+
+// getWorkspaceDisplayPath returns the relative path to the current Makefile for display in status bar
+func (m Model) getWorkspaceDisplayPath() string {
+	if m.WorkspaceManager == nil {
+		return filepath.Base(m.MakefilePath)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return filepath.Base(m.MakefilePath)
+	}
+
+	relPath := m.WorkspaceManager.GetRelativePath(m.MakefilePath, cwd)
+	if relPath == "" {
+		return filepath.Base(m.MakefilePath)
+	}
+
+	return relPath
 }

--- a/internal/tui/view_workspace.go
+++ b/internal/tui/view_workspace.go
@@ -1,0 +1,60 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// renderWorkspaceView renders the workspace picker view
+func (m Model) renderWorkspaceView() string {
+	return m.renderWorkspaceList()
+}
+
+// renderWorkspaceList renders recent and discovered workspaces
+func (m Model) renderWorkspaceList() string {
+	var builder strings.Builder
+
+	// Title
+	title := TitleStyle.Render("Switch Workspace")
+	builder.WriteString(title + "\n\n")
+
+	// Render workspace list
+	builder.WriteString(m.WorkspaceList.View())
+
+	// Apply border style matching other views
+	containerStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(SecondaryColor).
+		Padding(1, 2).
+		Width(m.Width - 2)
+
+	content := containerStyle.Render(builder.String())
+
+	// Status bar
+	items := m.WorkspaceList.Items()
+	recentCount := 0
+	discoveredCount := 0
+	for _, item := range items {
+		if ws, ok := item.(WorkspaceItem); ok {
+			if ws.Workspace.AccessCount > 0 {
+				recentCount++
+			} else {
+				discoveredCount++
+			}
+		}
+	}
+
+	var leftContent string
+	if discoveredCount > 0 {
+		leftContent = fmt.Sprintf("%d recent • %d discovered", recentCount, discoveredCount)
+	} else {
+		leftContent = fmt.Sprintf("%d workspaces", recentCount)
+	}
+	rightContent := "enter: switch • f: favorite • esc/w: cancel • q: quit"
+
+	statusBar := renderStatusBar(m.Width, leftContent, rightContent)
+
+	return content + "\n" + statusBar
+}

--- a/internal/workspace/browser.go
+++ b/internal/workspace/browser.go
@@ -1,0 +1,212 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// DirEntry represents a file or directory entry in the browser
+type DirEntry struct {
+	Name       string    // Entry name (not full path)
+	Path       string    // Absolute path
+	IsDir      bool      // True if directory
+	IsMakefile bool      // True if this is a Makefile
+	Size       int64     // File size in bytes
+}
+
+// BrowserState manages the file browser navigation state
+type BrowserState struct {
+	CurrentDir  string     // Absolute path to current directory
+	Entries     []DirEntry // Entries in current directory
+	SelectedIdx int        // Currently selected entry index
+	Error       error      // Last error encountered
+}
+
+// NewBrowser creates a new file browser starting at the given directory
+func NewBrowser(startDir string) (*BrowserState, error) {
+	// Convert to absolute path
+	absPath, err := filepath.Abs(startDir)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if directory exists
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		// If it's a file, use its parent directory
+		absPath = filepath.Dir(absPath)
+	}
+
+	browser := &BrowserState{
+		CurrentDir:  absPath,
+		SelectedIdx: 0,
+	}
+
+	// Load initial entries
+	if err := browser.RefreshEntries(); err != nil {
+		return nil, err
+	}
+
+	return browser, nil
+}
+
+// RefreshEntries reloads the directory entries
+func (b *BrowserState) RefreshEntries() error {
+	entries, err := os.ReadDir(b.CurrentDir)
+	if err != nil {
+		b.Error = err
+		return err
+	}
+
+	b.Entries = make([]DirEntry, 0, len(entries)+1)
+
+	// Add parent directory entry if not at root
+	if b.CurrentDir != "/" && b.CurrentDir != filepath.VolumeName(b.CurrentDir)+"/" {
+		b.Entries = append(b.Entries, DirEntry{
+			Name:  "..",
+			Path:  filepath.Dir(b.CurrentDir),
+			IsDir: true,
+		})
+	}
+
+	// Convert to DirEntry and sort
+	for _, entry := range entries {
+		// Skip hidden files/directories (start with .)
+		if strings.HasPrefix(entry.Name(), ".") && entry.Name() != ".." {
+			continue
+		}
+
+		fullPath := filepath.Join(b.CurrentDir, entry.Name())
+		isDir := entry.IsDir()
+		isMakefile := false
+		var size int64
+
+		if !isDir {
+			// Check if it's a Makefile
+			isMakefile = IsMakefile(entry.Name())
+
+			// Get file size
+			if info, err := entry.Info(); err == nil {
+				size = info.Size()
+			}
+		}
+
+		b.Entries = append(b.Entries, DirEntry{
+			Name:       entry.Name(),
+			Path:       fullPath,
+			IsDir:      isDir,
+			IsMakefile: isMakefile,
+			Size:       size,
+		})
+	}
+
+	// Sort: directories first, then files, alphabetically
+	sort.Slice(b.Entries, func(i, j int) bool {
+		// ".." always first
+		if b.Entries[i].Name == ".." {
+			return true
+		}
+		if b.Entries[j].Name == ".." {
+			return false
+		}
+
+		// Directories before files
+		if b.Entries[i].IsDir != b.Entries[j].IsDir {
+			return b.Entries[i].IsDir
+		}
+
+		// Alphabetical
+		return strings.ToLower(b.Entries[i].Name) < strings.ToLower(b.Entries[j].Name)
+	})
+
+	// Keep selection in bounds
+	if b.SelectedIdx >= len(b.Entries) {
+		b.SelectedIdx = len(b.Entries) - 1
+	}
+	if b.SelectedIdx < 0 {
+		b.SelectedIdx = 0
+	}
+
+	b.Error = nil
+	return nil
+}
+
+// NavigateUp moves to the parent directory
+func (b *BrowserState) NavigateUp() error {
+	parent := filepath.Dir(b.CurrentDir)
+	if parent == b.CurrentDir {
+		// Already at root
+		return nil
+	}
+
+	b.CurrentDir = parent
+	b.SelectedIdx = 0
+	return b.RefreshEntries()
+}
+
+// NavigateInto enters the selected directory or selects a Makefile
+func (b *BrowserState) NavigateInto() error {
+	if len(b.Entries) == 0 {
+		return nil
+	}
+
+	selected := b.Entries[b.SelectedIdx]
+
+	if selected.IsDir {
+		// Enter directory
+		b.CurrentDir = selected.Path
+		b.SelectedIdx = 0
+		return b.RefreshEntries()
+	}
+
+	// For files, do nothing (caller will handle Makefile selection)
+	return nil
+}
+
+// GetCurrentSelection returns the currently selected entry
+func (b *BrowserState) GetCurrentSelection() *DirEntry {
+	if len(b.Entries) == 0 || b.SelectedIdx < 0 || b.SelectedIdx >= len(b.Entries) {
+		return nil
+	}
+	return &b.Entries[b.SelectedIdx]
+}
+
+// MoveUp moves selection up one entry
+func (b *BrowserState) MoveUp() {
+	if b.SelectedIdx > 0 {
+		b.SelectedIdx--
+	}
+}
+
+// MoveDown moves selection down one entry
+func (b *BrowserState) MoveDown() {
+	if b.SelectedIdx < len(b.Entries)-1 {
+		b.SelectedIdx++
+	}
+}
+
+// GetBreadcrumb returns a formatted breadcrumb path
+func (b *BrowserState) GetBreadcrumb() string {
+	// Shorten home directory to ~
+	home, err := os.UserHomeDir()
+	if err == nil && strings.HasPrefix(b.CurrentDir, home) {
+		return "~" + strings.TrimPrefix(b.CurrentDir, home)
+	}
+	return b.CurrentDir
+}
+
+// CountMakefiles returns the number of Makefiles in the current directory
+func (b *BrowserState) CountMakefiles() int {
+	count := 0
+	for _, entry := range b.Entries {
+		if entry.IsMakefile {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/workspace/discovery.go
+++ b/internal/workspace/discovery.go
@@ -1,0 +1,211 @@
+package workspace
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	defaultMaxDepth    = 3
+	defaultScanTimeout = 5 * time.Second
+)
+
+// DiscoveryOptions configures Makefile discovery behavior
+type DiscoveryOptions struct {
+	MaxDepth        int           // Maximum directory depth to search (default: 3)
+	ExcludePatterns []string      // Directory names to exclude
+	Timeout         time.Duration // Max time to scan (default: 5s)
+}
+
+// DefaultDiscoveryOptions returns default discovery settings
+func DefaultDiscoveryOptions() DiscoveryOptions {
+	return DiscoveryOptions{
+		MaxDepth: defaultMaxDepth,
+		ExcludePatterns: []string{
+			".git",
+			"node_modules",
+			"vendor",
+			".venv",
+			"venv",
+			"build",
+			"dist",
+			".cache",
+			".idea",
+			".vscode",
+			"target", // Rust/Java build dir
+			"__pycache__",
+		},
+		Timeout: defaultScanTimeout,
+	}
+}
+
+// DiscoveryResult represents a discovered Makefile
+type DiscoveryResult struct {
+	Path    string    // Absolute path to Makefile
+	RelPath string    // Relative path from search root
+	ModTime time.Time // Last modification time
+}
+
+// pathDepth tracks path and its depth for BFS
+type pathDepth struct {
+	path  string
+	depth int
+}
+
+// DiscoverMakefiles finds all Makefiles in a directory tree using BFS
+func DiscoverMakefiles(rootDir string, opts DiscoveryOptions) ([]DiscoveryResult, error) {
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), opts.Timeout)
+	defer cancel()
+
+	// Build exclusion map for fast lookup
+	excludeDirs := make(map[string]bool)
+	for _, pattern := range opts.ExcludePatterns {
+		excludeDirs[pattern] = true
+	}
+
+	var results []DiscoveryResult
+
+	// BFS queue
+	queue := []pathDepth{{path: rootDir, depth: 0}}
+
+	for len(queue) > 0 {
+		// Check timeout
+		select {
+		case <-ctx.Done():
+			// Timeout reached, return what we have
+			return results, nil
+		default:
+		}
+
+		// Dequeue
+		current := queue[0]
+		queue = queue[1:]
+
+		// Check depth limit
+		if current.depth > opts.MaxDepth {
+			continue
+		}
+
+		// Read directory entries
+		entries, err := os.ReadDir(current.path)
+		if err != nil {
+			// Permission denied or other error - skip this directory
+			continue
+		}
+
+		for _, entry := range entries {
+			fullPath := filepath.Join(current.path, entry.Name())
+
+			if entry.IsDir() {
+				// Skip excluded directories
+				if excludeDirs[entry.Name()] {
+					continue
+				}
+
+				// Add to queue for BFS
+				queue = append(queue, pathDepth{
+					path:  fullPath,
+					depth: current.depth + 1,
+				})
+			} else {
+				// Check if it's a Makefile
+				if IsMakefile(entry.Name()) {
+					// Get file info for mod time
+					info, err := entry.Info()
+					if err != nil {
+						continue
+					}
+
+					// Compute relative path from root
+					relPath, err := filepath.Rel(rootDir, fullPath)
+					if err != nil {
+						relPath = fullPath
+					}
+
+					results = append(results, DiscoveryResult{
+						Path:    fullPath,
+						RelPath: relPath,
+						ModTime: info.ModTime(),
+					})
+				}
+			}
+		}
+	}
+
+	return results, nil
+}
+
+// FindMakefilesInParents searches upward from a directory to find Makefiles
+// Useful for finding project root when in a subdirectory
+func FindMakefilesInParents(startDir string, maxLevels int) ([]string, error) {
+	var results []string
+	currentDir := startDir
+
+	for level := 0; level < maxLevels; level++ {
+		// Check for Makefile in current directory
+		makefilePath := filepath.Join(currentDir, "Makefile")
+		if _, err := os.Stat(makefilePath); err == nil {
+			absPath, _ := filepath.Abs(makefilePath)
+			results = append(results, absPath)
+		}
+
+		// Check for makefile (lowercase)
+		makefilePath = filepath.Join(currentDir, "makefile")
+		if _, err := os.Stat(makefilePath); err == nil {
+			absPath, _ := filepath.Abs(makefilePath)
+			results = append(results, absPath)
+		}
+
+		// Move up one directory
+		parent := filepath.Dir(currentDir)
+		if parent == currentDir {
+			// Reached root
+			break
+		}
+		currentDir = parent
+	}
+
+	return results, nil
+}
+
+// IsMakefile returns true if the given path is a Makefile
+func IsMakefile(path string) bool {
+	name := filepath.Base(path)
+
+	// Exact matches
+	if name == "Makefile" || name == "makefile" || name == "GNUmakefile" {
+		return true
+	}
+
+	// Files starting with "Makefile" (e.g., Makefile.local, Makefile.inc)
+	if strings.HasPrefix(name, "Makefile") || strings.HasPrefix(name, "makefile") {
+		return true
+	}
+
+	// Common Makefile extensions
+	ext := strings.ToLower(filepath.Ext(name))
+	return ext == ".mk" || ext == ".mak"
+}
+
+// FormatSize formats a file size in human-readable format
+func FormatSize(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return strings.Join([]string{string(rune(bytes)), "B"}, "")
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return strings.Join([]string{
+		strings.TrimRight(strings.TrimRight(
+			strings.Join([]string{string(rune(int(float64(bytes)/float64(div)*10)/10)), ".", string(rune(int(float64(bytes)/float64(div)*10)%10))}, ""),
+			"0"), "."),
+		[]string{"B", "KB", "MB", "GB", "TB"}[exp],
+	}, " ")
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -1,0 +1,219 @@
+package workspace
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	maxRecentWorkspaces = 10
+	workspaceFileName   = "workspaces.json"
+)
+
+// Workspace represents a Makefile workspace
+type Workspace struct {
+	Path         string    `json:"path"`           // Absolute path to Makefile
+	LastAccessed time.Time `json:"last_accessed"`  // When last accessed
+	AccessCount  int       `json:"access_count"`   // Total access count
+	IsFavorite   bool      `json:"is_favorite"`    // User-marked favorite
+	DisplayName  string    `json:"display_name,omitempty"` // Optional custom name
+}
+
+// Manager handles workspace persistence and operations
+type Manager struct {
+	Workspaces []Workspace `json:"workspaces"`
+	path       string      // Cache file path
+}
+
+// Load reads workspace data from the cache directory
+// Returns an empty manager on error (graceful degradation)
+func Load() (*Manager, error) {
+	path, err := getCachePath()
+	if err != nil {
+		return newEmpty(), fmt.Errorf("failed to get cache path: %w", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		// File doesn't exist yet - return empty manager
+		if os.IsNotExist(err) {
+			m := newEmpty()
+			m.path = path
+			return m, nil
+		}
+		return newEmpty(), fmt.Errorf("failed to read workspaces file: %w", err)
+	}
+
+	var m Manager
+	if err := json.Unmarshal(data, &m); err != nil {
+		// Corrupt JSON - return empty manager and log warning
+		_, _ = fmt.Fprintf(os.Stderr, "Warning: corrupt workspaces file, resetting: %v\n", err)
+		m = *newEmpty()
+	}
+
+	if m.Workspaces == nil {
+		m.Workspaces = []Workspace{}
+	}
+
+	// Clean up invalid workspace paths (files that no longer exist)
+	m.cleanupInvalidWorkspaces()
+
+	m.path = path
+	return &m, nil
+}
+
+// Save writes workspace data to disk
+func (m *Manager) Save() error {
+	if m.path == "" {
+		return fmt.Errorf("workspace path not set")
+	}
+
+	// Ensure cache directory exists
+	dir := filepath.Dir(m.path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create cache directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal workspaces: %w", err)
+	}
+
+	if err := os.WriteFile(m.path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write workspaces file: %w", err)
+	}
+
+	return nil
+}
+
+// RecordAccess updates or creates a workspace entry when accessed
+func (m *Manager) RecordAccess(makefilePath string) {
+	// Convert to absolute path
+	absPath, err := filepath.Abs(makefilePath)
+	if err != nil {
+		absPath = makefilePath
+	}
+
+	// Find existing workspace
+	for i := range m.Workspaces {
+		if m.Workspaces[i].Path == absPath {
+			m.Workspaces[i].LastAccessed = time.Now()
+			m.Workspaces[i].AccessCount++
+			return
+		}
+	}
+
+	// Create new workspace entry
+	m.Workspaces = append(m.Workspaces, Workspace{
+		Path:         absPath,
+		LastAccessed: time.Now(),
+		AccessCount:  1,
+		IsFavorite:   false,
+	})
+}
+
+// GetRecent returns the most recently accessed workspaces, sorted by last access time
+// Favorites always appear first, then sorted by last accessed
+func (m *Manager) GetRecent(limit int) []Workspace {
+	if limit <= 0 {
+		limit = maxRecentWorkspaces
+	}
+
+	// Sort workspaces: favorites first, then by last accessed
+	sorted := make([]Workspace, len(m.Workspaces))
+	copy(sorted, m.Workspaces)
+
+	sort.Slice(sorted, func(i, j int) bool {
+		// Favorites first
+		if sorted[i].IsFavorite != sorted[j].IsFavorite {
+			return sorted[i].IsFavorite
+		}
+		// Then by last accessed
+		return sorted[i].LastAccessed.After(sorted[j].LastAccessed)
+	})
+
+	// Return up to limit
+	if len(sorted) > limit {
+		return sorted[:limit]
+	}
+	return sorted
+}
+
+// ToggleFavorite toggles the favorite status of a workspace
+func (m *Manager) ToggleFavorite(makefilePath string) {
+	// Convert to absolute path
+	absPath, err := filepath.Abs(makefilePath)
+	if err != nil {
+		absPath = makefilePath
+	}
+
+	// Find and toggle
+	for i := range m.Workspaces {
+		if m.Workspaces[i].Path == absPath {
+			m.Workspaces[i].IsFavorite = !m.Workspaces[i].IsFavorite
+			return
+		}
+	}
+}
+
+// GetRelativePath returns a display-friendly relative path from cwd to makefile
+// Returns basename on error or if relative path is complex
+func (m *Manager) GetRelativePath(makefilePath, cwd string) string {
+	// Try to compute relative path
+	relPath, err := filepath.Rel(cwd, makefilePath)
+	if err != nil {
+		// Fallback to basename
+		return filepath.Base(makefilePath)
+	}
+
+	// Clean up relative path for display
+	// "Makefile" -> "./Makefile"
+	if relPath == "Makefile" {
+		return "./Makefile"
+	}
+
+	// Ensure paths that don't start with "." or ".." get "./" prefix
+	if !strings.HasPrefix(relPath, ".") {
+		return "./" + relPath
+	}
+
+	return relPath
+}
+
+// cleanupInvalidWorkspaces removes workspace entries for Makefiles that no longer exist
+func (m *Manager) cleanupInvalidWorkspaces() {
+	valid := make([]Workspace, 0, len(m.Workspaces))
+	for _, ws := range m.Workspaces {
+		if _, err := os.Stat(ws.Path); err == nil {
+			valid = append(valid, ws)
+		}
+	}
+	m.Workspaces = valid
+}
+
+// newEmpty creates a new empty workspace manager
+func newEmpty() *Manager {
+	return &Manager{
+		Workspaces: []Workspace{},
+	}
+}
+
+// NewEmpty creates a new empty workspace manager (exported for tests and error cases)
+func NewEmpty() *Manager {
+	return newEmpty()
+}
+
+// getCachePath returns the path to the workspaces cache file
+func getCachePath() (string, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(cacheDir, "lazymake", workspaceFileName), nil
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,6 @@
+package version
+
+// Version is the current version of Lazymake
+// This can be set at build time using:
+//   go build -ldflags "-X github.com/rshelekhov/lazymake/version.Version=x.y.z"
+var Version = "dev"


### PR DESCRIPTION
Implement workspace switching feature (press 'w') that allows quick navigation between different Makefiles in a project.

Key features:
- Automatic discovery: Scans project tree (3 levels) to find all Makefiles
- Recent workspaces: Tracks last 10 accessed Makefiles with timestamps
- Discovered workspaces: Shows found Makefiles not yet accessed
- Favorites: Star frequently used workspaces (press 'f')
- Smart exclusions: Skips .git, node_modules, vendor, build dirs
- Status bar integration: Shows current Makefile path
- Per-project history: Each Makefile maintains its own execution history
- Persistent storage: ~/.cache/lazymake/workspaces.json

Implementation:
- Workspace manager with BFS discovery algorithm
- Custom list delegate for workspace items with "time ago" formatting
- Visual distinction between recent and discovered workspaces
- Workspace state in TUI model with seamless switching
- Browser functionality removed in favor of automatic discovery

Documentation:
- Updated README.md with workspace management section
- Updated FEATURES.md marking feature #7 as complete
- Added keyboard shortcuts and usage examples