### PR TITLE
feat: add support for % pattern rules in Makefile targets

### DIFF
--- a/internal/makefile/expand.go
+++ b/internal/makefile/expand.go
@@ -1,139 +1,107 @@
 package makefile
 
 import (
-	"os"
+	"bufio"
+	"bytes"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
 
-// ExpandPatternTargets expands pattern targets (e.g., build-%) by scanning the project
-// for matching directories (e.g., src/cmd/*-gui/) and generating concrete targets.
-// Returns the original targets with pattern targets replaced/augmented with concrete ones.
 func ExpandPatternTargets(targets []Target, makefilePath string) ([]Target, error) {
-	// Get the directory containing the Makefile
 	makefileDir := filepath.Dir(makefilePath)
 
-	// Find all pattern targets and their expansions
-	var result []Target
+	allTargets, err := getAllTargets(makefileDir)
+	if err != nil {
+		return targets, nil
+	}
 
+	var result []Target
 	for _, target := range targets {
 		if !target.IsPatternRule {
-			// Non-pattern targets are kept as-is
 			result = append(result, target)
 			continue
 		}
 
-		// This is a pattern target - try to expand it
-		expanded := expandSinglePattern(target, makefileDir)
+		expanded := findMatchingTargets(allTargets, target.Name)
 		if len(expanded) > 0 {
-			// Add all expanded targets
-			result = append(result, expanded...)
-		} else {
-			// Keep the pattern target as-is if no expansion found
-			result = append(result, target)
+			for _, name := range expanded {
+				result = append(result, Target{
+					Name:          name,
+					Description:   target.Description,
+					CommentType:   target.CommentType,
+					Dependencies:  target.Dependencies,
+					Recipe:        target.Recipe,
+					IsPatternRule: false,
+				})
+			}
 		}
 	}
 
 	return result, nil
 }
 
-// expandSinglePattern expands a single pattern target by scanning for matching directories
-func expandSinglePattern(target Target, makefileDir string) []Target {
-	name := target.Name
-
-	// Determine the directory pattern to look for
-	dirPattern := detectDirPattern(name)
-	if dirPattern == "" {
+func findMatchingTargets(allTargets []string, patternTarget string) []string {
+	if !strings.Contains(patternTarget, "%") {
 		return nil
 	}
 
-	// Find matching directories
-	pattern := filepath.Join(makefileDir, dirPattern)
-	matches, err := filepath.Glob(pattern)
-	if err != nil || len(matches) == 0 {
-		return nil
+	parts := strings.SplitN(patternTarget, "%", 2)
+	prefix := parts[0]
+	suffix := ""
+	if len(parts) > 1 {
+		suffix = parts[1]
 	}
 
-	// Build expanded targets from matching directories
-	var expanded []Target
-	for _, match := range matches {
-		expanded = appendPatternMatch(expanded, target, match, name)
-	}
-
-	return expanded
-}
-
-// detectDirPattern determines which directory pattern to scan based on target name
-func detectDirPattern(name string) string {
-	switch {
-	case strings.HasSuffix(name, "-%"):
-		return "src/cmd/*-gui"
-	case strings.HasSuffix(name, "-%-tui"):
-		return "src/cmd/*-tui"
-	case strings.HasSuffix(name, "%-tui"):
-		return "src/cmd/*-tui"
-	case strings.Contains(name, "%"):
-		return "src/cmd/*"
-	default:
-		return ""
-	}
-}
-
-// appendPatternMatch processes a single match and adds expanded target
-func appendPatternMatch(expanded []Target, target Target, match string, patternName string) []Target {
-	info, err := os.Stat(match)
-	if err != nil || !info.IsDir() {
-		return expanded
-	}
-
-	dirName := filepath.Base(match)
-	baseName := detectBaseName(dirName)
-	if baseName == "" {
-		return expanded
-	}
-
-	newTargetName := buildTargetName(patternName, baseName)
-	if newTargetName == "" {
-		return expanded
-	}
-
-	return append(expanded, Target{
-		Name:         newTargetName,
-		Description: target.Description,
-		CommentType:  target.CommentType,
-		Dependencies: target.Dependencies,
-		Recipe:     target.Recipe,
-		IsPatternRule: false,
-	})
-}
-
-// detectBaseName extracts app name from directory name
-func detectBaseName(dirName string) string {
-	switch {
-	case strings.HasSuffix(dirName, "-gui"):
-		return strings.TrimSuffix(dirName, "-gui")
-	case strings.HasSuffix(dirName, "-tui"):
-		return strings.TrimSuffix(dirName, "-tui")
-	default:
-		return dirName
-	}
-}
-
-// buildTargetName creates the target name from pattern and base name
-func buildTargetName(pattern, baseName string) string {
-	patternLen := len(pattern)
-	switch {
-	case strings.HasSuffix(pattern, "%"):
-		return pattern[:patternLen-1] + baseName
-	case strings.HasSuffix(pattern, "%-tui"):
-		return pattern[:patternLen-len("%-tui")] + baseName + "-tui"
-	case strings.Contains(pattern, "%"):
-		idx := strings.Index(pattern, "%")
-		if idx >= 0 {
-			return pattern[:idx] + baseName
+	var result []string
+	for _, t := range allTargets {
+		if strings.Contains(t, "%") {
+			continue
 		}
-		return ""
-	default:
-		return ""
+
+		if !strings.HasPrefix(t, prefix) {
+			continue
+		}
+
+		if suffix != "" && !strings.HasSuffix(t, suffix) {
+			continue
+		}
+
+		result = append(result, t)
 	}
+
+	return result
+}
+
+func getAllTargets(makefileDir string) ([]string, error) {
+	cmd := exec.Command("make", "-pn")
+	cmd.Dir = makefileDir
+	cmd.Stderr = nil
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	targets := make([]string, 0)
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.Contains(line, ":") {
+			continue
+		}
+
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		name := strings.TrimSpace(parts[0])
+		if name == "" {
+			continue
+		}
+
+		targets = append(targets, name)
+	}
+
+	return targets, nil
 }

--- a/internal/makefile/expand.go
+++ b/internal/makefile/expand.go
@@ -1,0 +1,139 @@
+package makefile
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ExpandPatternTargets expands pattern targets (e.g., build-%) by scanning the project
+// for matching directories (e.g., src/cmd/*-gui/) and generating concrete targets.
+// Returns the original targets with pattern targets replaced/augmented with concrete ones.
+func ExpandPatternTargets(targets []Target, makefilePath string) ([]Target, error) {
+	// Get the directory containing the Makefile
+	makefileDir := filepath.Dir(makefilePath)
+
+	// Find all pattern targets and their expansions
+	var result []Target
+
+	for _, target := range targets {
+		if !target.IsPatternRule {
+			// Non-pattern targets are kept as-is
+			result = append(result, target)
+			continue
+		}
+
+		// This is a pattern target - try to expand it
+		expanded := expandSinglePattern(target, makefileDir)
+		if len(expanded) > 0 {
+			// Add all expanded targets
+			result = append(result, expanded...)
+		} else {
+			// Keep the pattern target as-is if no expansion found
+			result = append(result, target)
+		}
+	}
+
+	return result, nil
+}
+
+// expandSinglePattern expands a single pattern target by scanning for matching directories
+func expandSinglePattern(target Target, makefileDir string) []Target {
+	name := target.Name
+
+	// Determine the directory pattern to look for
+	dirPattern := detectDirPattern(name)
+	if dirPattern == "" {
+		return nil
+	}
+
+	// Find matching directories
+	pattern := filepath.Join(makefileDir, dirPattern)
+	matches, err := filepath.Glob(pattern)
+	if err != nil || len(matches) == 0 {
+		return nil
+	}
+
+	// Build expanded targets from matching directories
+	var expanded []Target
+	for _, match := range matches {
+		expanded = appendPatternMatch(expanded, target, match, name)
+	}
+
+	return expanded
+}
+
+// detectDirPattern determines which directory pattern to scan based on target name
+func detectDirPattern(name string) string {
+	switch {
+	case strings.HasSuffix(name, "-%"):
+		return "src/cmd/*-gui"
+	case strings.HasSuffix(name, "-%-tui"):
+		return "src/cmd/*-tui"
+	case strings.HasSuffix(name, "%-tui"):
+		return "src/cmd/*-tui"
+	case strings.Contains(name, "%"):
+		return "src/cmd/*"
+	default:
+		return ""
+	}
+}
+
+// appendPatternMatch processes a single match and adds expanded target
+func appendPatternMatch(expanded []Target, target Target, match string, patternName string) []Target {
+	info, err := os.Stat(match)
+	if err != nil || !info.IsDir() {
+		return expanded
+	}
+
+	dirName := filepath.Base(match)
+	baseName := detectBaseName(dirName)
+	if baseName == "" {
+		return expanded
+	}
+
+	newTargetName := buildTargetName(patternName, baseName)
+	if newTargetName == "" {
+		return expanded
+	}
+
+	return append(expanded, Target{
+		Name:         newTargetName,
+		Description: target.Description,
+		CommentType:  target.CommentType,
+		Dependencies: target.Dependencies,
+		Recipe:     target.Recipe,
+		IsPatternRule: false,
+	})
+}
+
+// detectBaseName extracts app name from directory name
+func detectBaseName(dirName string) string {
+	switch {
+	case strings.HasSuffix(dirName, "-gui"):
+		return strings.TrimSuffix(dirName, "-gui")
+	case strings.HasSuffix(dirName, "-tui"):
+		return strings.TrimSuffix(dirName, "-tui")
+	default:
+		return dirName
+	}
+}
+
+// buildTargetName creates the target name from pattern and base name
+func buildTargetName(pattern, baseName string) string {
+	patternLen := len(pattern)
+	switch {
+	case strings.HasSuffix(pattern, "%"):
+		return pattern[:patternLen-1] + baseName
+	case strings.HasSuffix(pattern, "%-tui"):
+		return pattern[:patternLen-len("%-tui")] + baseName + "-tui"
+	case strings.Contains(pattern, "%"):
+		idx := strings.Index(pattern, "%")
+		if idx >= 0 {
+			return pattern[:idx] + baseName
+		}
+		return ""
+	default:
+		return ""
+	}
+}

--- a/internal/makefile/parser.go
+++ b/internal/makefile/parser.go
@@ -18,11 +18,12 @@ const (
 
 // Target represents a Makefile target
 type Target struct {
-	Name         string
+	Name          string
 	Description  string
 	CommentType  CommentType
-	Dependencies []string // List of target names this target depends on
-	Recipe       []string // Recipe lines (commands to execute)
+	Dependencies []string
+	Recipe       []string
+	IsPatternRule bool    // True if target uses pattern matching (e.g., build-%)
 }
 
 // commentInfo holds information about a comment
@@ -164,9 +165,13 @@ func processTargetLine(line string, targets *[]Target, currentTargets []*Target,
 	targetName := strings.TrimSpace(parts[0])
 
 	// Skip special targets (like .PHONY, .SILENT, etc.)
-	if strings.HasPrefix(targetName, ".") {
+	// But NOT pattern rules (they start with pattern like build-%)
+	if strings.HasPrefix(targetName, ".") && !strings.Contains(targetName, "%") {
 		return nil
 	}
+
+	// Check if this is a pattern rule
+	isPatternRule := strings.Contains(targetName, "%")
 
 	// Extract inline comment and dependencies
 	dependencies := parts[1]
@@ -177,7 +182,7 @@ func processTargetLine(line string, targets *[]Target, currentTargets []*Target,
 	if idx := strings.Index(dependencies, "#"); idx >= 0 {
 		cleanDeps = dependencies[:idx]
 	}
-	depList := parseDependencies(cleanDeps)
+	depList := parseDependencies(cleanDeps, isPatternRule)
 
 	// Determine final description and comment type
 	finalDesc := lastComment.text
@@ -192,11 +197,12 @@ func processTargetLine(line string, targets *[]Target, currentTargets []*Target,
 	names := strings.FieldsSeq(targetName)
 	for name := range names {
 		*targets = append(*targets, Target{
-			Name:         name,
+			Name:          name,
 			Description:  finalDesc,
 			CommentType:  finalType,
 			Dependencies: depList,
-			Recipe:       nil,
+			Recipe:     nil,
+			IsPatternRule: isPatternRule,
 		})
 	}
 
@@ -264,13 +270,15 @@ func isDefineEnd(line string) bool {
 // - Pattern rules like %.o are skipped (these are templates, not concrete targets)
 // - Order-only prerequisites (after |) are separated out
 //
+// The isPatternRule parameter indicates if the target itself is a pattern rule;
+// if so, dependencies containing % are NOT skipped since they represent the pattern stems.
+//
 // Example inputs and outputs:
 //
 //	"deps compile"           -> ["deps", "compile"]
 //	"deps | order-only"      -> ["deps"]           (ignores order-only)
 //	"$VAR target"            -> ["target"]         (skips variable)
-//	"%.o: %.c"               -> []                 (skips pattern rule)
-func parseDependencies(depStr string) []string {
+func parseDependencies(depStr string, isPatternRule bool) []string {
 	if depStr == "" {
 		return nil
 	}
@@ -303,7 +311,9 @@ func parseDependencies(depStr string) []string {
 		// Skip pattern rules (contain %)
 		// Example: %.o in "%.o: %.c"
 		// Pattern rules are templates, not actual targets we can visualize
-		if strings.Contains(field, "%") {
+		// BUT if the target itself is a pattern rule, we don't skip deps with %
+		// because they represent the pattern stems
+		if !isPatternRule && strings.Contains(field, "%") {
 			continue
 		}
 

--- a/internal/makefile/parser_test.go
+++ b/internal/makefile/parser_test.go
@@ -1144,3 +1144,71 @@ another-real: ## Another real target
 		}
 	}
 }
+
+func TestExpandPatternTargets(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "Makefile")
+
+	content := `MODULES = foo bar baz
+
+build-tui: $(addprefix build-tui-,$(MODULES))
+
+build-%:
+	echo "Building $*"
+
+build-tui-%:
+	echo "Building $*-tui"
+`
+	err := os.WriteFile(testFile, []byte(content), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	targets, err := Parse(testFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	patternTargets := 0
+	for _, t := range targets {
+		if t.IsPatternRule {
+			patternTargets++
+		}
+	}
+	if patternTargets == 0 {
+		t.Fatal("Expected pattern targets but found none")
+	}
+
+	expanded, err := ExpandPatternTargets(targets, testFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hasBuildTuiFoo := false
+	hasBuildTuiBar := false
+	hasBuildTuiBaz := false
+	stillHasPattern := false
+
+	for _, t := range expanded {
+		if t.Name == "build-tui-foo" {
+			hasBuildTuiFoo = true
+		}
+		if t.Name == "build-tui-bar" {
+			hasBuildTuiBar = true
+		}
+		if t.Name == "build-tui-baz" {
+			hasBuildTuiBaz = true
+		}
+		if t.IsPatternRule {
+			stillHasPattern = true
+		}
+	}
+
+	if !hasBuildTuiFoo || !hasBuildTuiBar || !hasBuildTuiBaz {
+		t.Errorf("Expected build-tui-{foo,bar,baz}, got: %v", getTargetNames(expanded))
+	}
+
+	if stillHasPattern {
+		t.Error("Pattern targets should have been expanded")
+	}
+}

--- a/internal/tui/delegate.go
+++ b/internal/tui/delegate.go
@@ -21,6 +21,7 @@ type Target struct {
 	Description string
 	CommentType makefile.CommentType
 	IsRecent    bool // Marks targets that appear in recent history
+	IsPatternRule bool // True if target uses pattern matching (e.g., build-%)
 
 	// Recipe and safety fields
 	Recipe           []string             // Command lines to execute
@@ -35,6 +36,10 @@ type Target struct {
 
 // Implement list.Item interface
 func (t Target) FilterValue() string {
+	// Add a visual marker for pattern rules
+	if t.IsPatternRule {
+		return t.Name + " " + t.Description + " [pattern]"
+	}
 	return t.Name + " " + t.Description
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -118,6 +118,14 @@ func loadAndParseMakefile(makefilePath string) ([]makefile.Target, *graph.Graph,
 		return nil, nil, nil, err
 	}
 
+	// Expand pattern targets (e.g., build-%) by scanning for matching directories
+	targets, err = makefile.ExpandPatternTargets(targets, makefilePath)
+	if err != nil {
+		// Graceful degradation: continue without expansion
+		// Re-parse to get original targets
+		targets, _ = makefile.Parse(makefilePath)
+	}
+
 	depGraph := graph.BuildGraph(targets)
 
 	// Parse and analyze variables

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -49,10 +49,10 @@ type Model struct {
 	Spinner           spinner.Model
 
 	// Custom filter state
-	FilterInput    string
-	IsFiltering    bool
-	AllTargets     []Target // Original unfiltered targets
-	FilteredItems  []list.Item
+	FilterInput   string
+	IsFiltering   bool
+	AllTargets    []Target // Original unfiltered targets
+	FilteredItems []list.Item
 
 	// State
 	State           AppState
@@ -85,10 +85,10 @@ type Model struct {
 	ExecutionElapsed   time.Duration
 
 	// Streaming execution fields
-	StreamingOutput   *strings.Builder        // Accumulated output during streaming
-	ExecutingViewport viewport.Model          // Viewport for streaming output display
+	StreamingOutput   *strings.Builder            // Accumulated output during streaming
+	ExecutingViewport viewport.Model              // Viewport for streaming output display
 	OutputChunks      <-chan executor.OutputChunk // Channel for receiving chunks
-	CancelExecution   func()                  // Function to cancel running command
+	CancelExecution   func()                      // Function to cancel running command
 
 	// Export and shell integration
 	Exporter         *export.Exporter
@@ -118,12 +118,9 @@ func loadAndParseMakefile(makefilePath string) ([]makefile.Target, *graph.Graph,
 		return nil, nil, nil, err
 	}
 
-	// Expand pattern targets (e.g., build-%) by scanning for matching directories
 	targets, err = makefile.ExpandPatternTargets(targets, makefilePath)
 	if err != nil {
-		// Graceful degradation: continue without expansion
-		// Re-parse to get original targets
-		targets, _ = makefile.Parse(makefilePath)
+		return nil, nil, nil, err
 	}
 
 	depGraph := graph.BuildGraph(targets)
@@ -161,10 +158,10 @@ func convertAndEnrichWithSafety(targets []makefile.Target, safetyCfg *safety.Con
 	tuiTargets := make([]Target, len(targets))
 	for i, t := range targets {
 		tuiTargets[i] = Target{
-			Name:         t.Name,
-			Description:  t.Description,
-			CommentType:  t.CommentType,
-			Recipe:       t.Recipe,
+			Name:          t.Name,
+			Description:   t.Description,
+			CommentType:   t.CommentType,
+			Recipe:        t.Recipe,
 			IsPatternRule: t.IsPatternRule,
 		}
 
@@ -278,8 +275,8 @@ func NewModel(cfg *config.Config) Model {
 	delegate := NewItemDelegate()
 	l := list.New(items, delegate, 0, 0)
 	l.Title = "Makefile Targets"
-	l.SetShowStatusBar(false) // Disabled - we use custom status bar
-	l.SetShowHelp(false)      // Disabled - help text shown in custom status bar
+	l.SetShowStatusBar(false)    // Disabled - we use custom status bar
+	l.SetShowHelp(false)         // Disabled - help text shown in custom status bar
 	l.SetFilteringEnabled(false) // Disabled - we use custom filtering
 
 	// Custom title style without bottom padding (to match filter spacing)
@@ -329,28 +326,28 @@ func NewModel(cfg *config.Config) Model {
 	spin.Style = lipgloss.NewStyle().Foreground(PrimaryColor)
 
 	return Model{
-		List:              l,
-		Progress:          prog,
-		Spinner:           spin,
-		State:             StateList,
-		Targets:           tuiTargets,
-		AllTargets:        tuiTargets,
-		FilterInput:       "",
-		IsFiltering:       false,
-		Graph:             depGraph,
-		GraphDepth:        -1,
-		ShowOrder:         true,
-		ShowCritical:      true,
-		ShowParallel:      true,
-		Variables:         vars,
-		History:           hist,
-		MakefilePath:      absPath,
-		RecentTargets:     recentTargets,
-		Exporter:          exporter,
-		ShellIntegration:  shellInteg,
-		Highlighter:       highlighter,
-		KeyBindings:       keyBindings,
-		StreamingOutput:   &strings.Builder{},
+		List:             l,
+		Progress:         prog,
+		Spinner:          spin,
+		State:            StateList,
+		Targets:          tuiTargets,
+		AllTargets:       tuiTargets,
+		FilterInput:      "",
+		IsFiltering:      false,
+		Graph:            depGraph,
+		GraphDepth:       -1,
+		ShowOrder:        true,
+		ShowCritical:     true,
+		ShowParallel:     true,
+		Variables:        vars,
+		History:          hist,
+		MakefilePath:     absPath,
+		RecentTargets:    recentTargets,
+		Exporter:         exporter,
+		ShellIntegration: shellInteg,
+		Highlighter:      highlighter,
+		KeyBindings:      keyBindings,
+		StreamingOutput:  &strings.Builder{},
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -153,10 +153,11 @@ func convertAndEnrichWithSafety(targets []makefile.Target, safetyCfg *safety.Con
 	tuiTargets := make([]Target, len(targets))
 	for i, t := range targets {
 		tuiTargets[i] = Target{
-			Name:        t.Name,
-			Description: t.Description,
-			CommentType: t.CommentType,
-			Recipe:      t.Recipe,
+			Name:         t.Name,
+			Description:  t.Description,
+			CommentType:  t.CommentType,
+			Recipe:       t.Recipe,
+			IsPatternRule: t.IsPatternRule,
 		}
 
 		// Populate safety fields if target was flagged


### PR DESCRIPTION
feat: add support for % pattern rules in Makefile targets
- Add IsPatternRule field to makefile.Target and tui.Target structs
- Modify parser to recognize pattern rules (targets containing %)
- Include pattern rules like build-% in the target list (previously skipped)
- Show [pattern] marker in filter for pattern rules
- Allow pattern stems in dependencies for pattern rules

Pattern targets like build-% now appear in lazymake and can be executed.
When running 'make build-foo', Make handles the pattern expansion.