### PR TITLE
docs: Update instructions for Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A terminal UI for browsing and running Makefile targets.
 
 ```bash
 # Install
-brew install rshelekhov/tap/lazymake
+brew install lazymake
 
 # Run in any directory with a Makefile
 lazymake
@@ -44,7 +44,7 @@ The dependency graph is particularly useful for understanding complex build syst
 
 ### Homebrew (macOS/Linux)
 ```bash
-brew install rshelekhov/tap/lazymake
+brew install lazymake
 ```
 
 ### Go


### PR DESCRIPTION
Removed the instructions for using a custom Tap. Lazymake can now be installed [directly](https://github.com/Homebrew/homebrew-core/commit/e2738ab3f26cf993956f459d502aeff80453f4b9) via Homebrew.