### PR TITLE
docs: add product roadmap and issue backlog

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,11 @@ This directory contains detailed guides and feature documentation to help you ge
 - [Performance Profiling](features/performance-tracking.md) - Track execution times and detect regressions
 - [Export & Shell Integration](features/export-shell-integration.md) - Export results and integrate with shell history
 
+## Product Planning
+
+- [Product Roadmap](product-roadmap.md) - Recommended product direction, phases, risks, and success metrics
+- [GitHub Issues Backlog](github-issues-backlog.md) - Ready-to-create issue drafts grouped by milestone
+
 ## Contributing
 
 See [CONTRIBUTING.md](../CONTRIBUTING.md) for contribution guidelines.

--- a/docs/github-issues-backlog.md
+++ b/docs/github-issues-backlog.md
@@ -1,184 +1,312 @@
 # GitHub Issues Backlog
 
-This document contains a ready-to-create backlog of GitHub issues for lazymake.
-All issues are written in English and include milestone, labels, summary, and acceptance criteria.
+This document contains ready-to-create issue drafts for the next product phases of lazymake.
+The `v0.4.0` backlog has already been delivered in `0.4.0` and `0.4.1`; the issues below focus on open product work.
 
-## 1) Shell history templates: support {target}, {makefile}, and {dir}
+All issue drafts are written in English so they can be pasted directly into GitHub.
 
-- Milestone: `v0.4.0`
-- Labels: `enhancement`, `area:shell`, `priority:P0`
+## `v0.5.0` Safe Execution
 
-### Summary
-Implement full template variable support for shell history entries: `{target}`, `{makefile}`, and `{dir}`.
-
-### Problem
-Current behavior only substitutes `{target}`, while docs describe support for `{makefile}` and `{dir}` as well.
-
-### Acceptance Criteria
-- `{target}`, `{makefile}`, and `{dir}` are all substituted in history output.
-- Missing/empty values are handled safely without panics.
-- Unit tests cover all placeholders and mixed template strings.
-- Documentation examples match actual behavior.
-
-## 2) Honor shell_integration.include_timestamp in runtime behavior
-
-- Milestone: `v0.4.0`
-- Labels: `enhancement`, `area:shell`, `priority:P0`
-
-### Summary
-Make `shell_integration.include_timestamp` actually control timestamp writing behavior.
-
-### Problem
-Config contains `include_timestamp`, but behavior is not consistently controlled by this flag.
-
-### Acceptance Criteria
-- `include_timestamp: true` writes timestamped entries where format supports it.
-- `include_timestamp: false` writes non-timestamped entries.
-- Behavior is covered by tests for supported shells.
-- Docs explicitly describe shell-specific behavior.
-
-## 3) Add fish shell history integration
-
-- Milestone: `v0.4.0`
-- Labels: `enhancement`, `area:shell`, `priority:P0`
-
-### Summary
-Implement fish history writer and wire it into shell auto-detection flow.
-
-### Problem
-Fish is detected but not supported end-to-end for writing execution history.
-
-### Acceptance Criteria
-- Fish writer appends entries in valid fish history format.
-- Auto mode initializes fish integration when `$SHELL` is fish.
-- File locking/concurrency safety matches other shell writers.
-- Integration tests verify append behavior and file output.
-
-## 4) Unify config merge behavior for export and shell_integration
-
-- Milestone: `v0.4.0`
-- Labels: `enhancement`, `area:config`, `priority:P0`
-
-### Summary
-Implement consistent global + project config merge logic for all config sections, not only safety.
-
-### Problem
-Docs describe merged config strategy, but runtime behavior is inconsistent across sections.
-
-### Acceptance Criteria
-- Global and project configs merge predictably for `export` and `shell_integration`.
-- Override/union rules are clearly defined and documented.
-- Tests validate merge precedence and list behavior.
-- Breaking changes are documented in changelog.
-
-## 5) Config behavior parity audit: docs vs runtime
-
-- Milestone: `v0.4.0`
-- Labels: `documentation`, `area:config`, `priority:P1`
-
-### Summary
-Audit and align all documented config options with runtime behavior.
-
-### Acceptance Criteria
-- Every documented config key is either implemented or removed from docs.
-- Defaults in docs match code defaults.
-- Example config file is validated against actual parser behavior.
-- A regression test checklist is added for future config changes.
-
-## 6) Add dry-run/explain mode for target execution
+### 1) Add dry-run / explain mode for target execution
 
 - Milestone: `v0.5.0`
-- Labels: `enhancement`, `area:tui`, `priority:P0`
+- Labels: `enhancement`, `area:tui`, `area:executor`, `priority:P0`
 
 ### Summary
-Provide a dry-run mode to preview commands before execution (e.g. via `make -n`).
+Provide a session-wide dry-run mode so users can preview what `make` would execute without actually running commands.
+
+### Why this matters
+Dry-run is the clearest next step for lazymake's safety and onboarding story. It reduces fear when exploring unfamiliar repositories and fits naturally with dangerous target detection.
 
 ### Acceptance Criteria
-- User can trigger dry-run from the target list view.
-- Dry-run output is shown in a dedicated preview/output view.
-- No target command is executed in dry-run mode.
-- UI communicates clearly whether user is in dry-run vs real execution.
+- User can start lazymake in dry-run mode via CLI and config.
+- Dry-run execution uses `make -n`.
+- UI clearly indicates dry-run mode in list, executing, and output views.
+- Dry-run does not write history, exports, or shell integration entries.
+- Dangerous targets still show confirmation before dry-run execution.
 
-## 7) Interactive execution parameters (ENV vars and make flags)
+### Dependencies
+- None
+
+### 2) Add interactive execution parameters (environment variables and make flags)
 
 - Milestone: `v0.5.0`
-- Labels: `enhancement`, `area:tui`, `priority:P0`
+- Labels: `enhancement`, `area:tui`, `area:executor`, `priority:P0`
 
 ### Summary
-Add a pre-run prompt to pass environment variables and make flags per execution.
+Add a pre-run flow that lets users pass temporary environment variables and make flags per execution.
+
+### Why this matters
+Many real workflows are not just `make build`; they are `ENV=prod make deploy -j4`. Without this, users still need to drop back to the shell for important cases.
 
 ### Acceptance Criteria
-- User can input key/value variables (e.g. `ENV=prod`, `TAG=v1`).
-- User can set run flags (e.g. `-j4`, `--always-make`).
+- User can enter key/value environment variables before execution.
+- User can enter make flags such as `-j4`, `-k`, or `--always-make`.
 - Command construction is safe and deterministic.
-- Cancel path returns to list view without execution.
+- Cancel path returns to the list without execution.
+- Output and history clearly reflect the chosen parameters.
 
-## 8) Saved run presets per target
+### Dependencies
+- Should share execution plumbing with dry-run where possible
+
+### 3) Add saved run presets per target and Makefile
 
 - Milestone: `v0.5.0`
-- Labels: `enhancement`, `area:history`, `priority:P1`
+- Labels: `enhancement`, `area:tui`, `area:history`, `priority:P1`
 
 ### Summary
-Allow saving and reusing named parameter presets per target and Makefile.
+Allow users to save named presets for a target, including environment variables and make flags.
+
+### Why this matters
+Presets turn lazymake from a browser into a repeatable execution console for real project workflows.
 
 ### Acceptance Criteria
-- Presets are stored per workspace/Makefile.
+- Presets are stored per Makefile and target.
 - User can create, select, update, and delete presets.
-- Last-used preset is quickly reusable.
-- Preset storage survives restart and handles missing targets gracefully.
+- Last-used preset is easy to reuse.
+- Presets survive restart.
+- Missing or renamed targets are handled gracefully.
 
-## 9) Export dependency graph to DOT and Mermaid
+### Dependencies
+- Interactive execution parameters
 
-- Milestone: `v0.5.0`
-- Labels: `enhancement`, `area:graph`, `priority:P1`
-
-### Summary
-Add graph export options for documentation and CI artifacts.
-
-### Acceptance Criteria
-- Export graph to DOT format.
-- Export graph to Mermaid format.
-- Exports include cycle and missing dependency annotations when present.
-- CLI and/or TUI entry points are documented.
-
-## 10) Rerun last target with previous parameters
+### 4) Add rerun-last flow with previous parameters
 
 - Milestone: `v0.5.0`
-- Labels: `enhancement`, `area:tui`, `priority:P1`
+- Labels: `enhancement`, `area:tui`, `area:history`, `priority:P1`
 
 ### Summary
-Add shortcut to re-run the most recent execution with same parameters.
+Add a shortcut to rerun the most recent execution with the same runtime parameters.
+
+### Why this matters
+This is the fastest path to making lazymake part of daily development loops.
 
 ### Acceptance Criteria
-- Shortcut is available from main list view.
-- Re-run includes previous env vars and flags.
-- UI confirms what will be re-run before starting.
-- Works across app restart when history exists.
+- Shortcut is available from the main list view.
+- Rerun includes previous environment variables and make flags.
+- UI confirms what is about to run.
+- Works after restart when history exists.
 
-## 11) Parser v2: hybrid model using make metadata
+### Dependencies
+- Interactive execution parameters
+
+### 5) Add TUI flow tests for execution modes and side effects
+
+- Milestone: `v0.5.0`
+- Labels: `testing`, `area:tui`, `priority:P1`
+
+### Summary
+Add automated tests for the most important execution flows, especially around dry-run and parameterized runs.
+
+### Why this matters
+Execution behavior is now central product logic. It should not rely only on manual testing.
+
+### Acceptance Criteria
+- Tests cover normal run, dry-run, cancel, and dangerous-target confirmation flows.
+- Tests verify side effects are skipped when expected.
+- Test structure makes future execution features easier to add safely.
+
+### Dependencies
+- Dry-run
+- Interactive execution parameters
+
+## `v0.6.0` Compatibility
+
+### 6) Parser v2: hybrid model using static parse plus make metadata
 
 - Milestone: `v0.6.0`
 - Labels: `enhancement`, `area:parser`, `priority:P0`
 
 ### Summary
-Introduce a hybrid parsing strategy combining static parse with `make` metadata (e.g. `make -qp`) for better compatibility.
+Introduce a hybrid parsing strategy that combines static parsing with `make` metadata such as `make -qp`.
+
+### Why this matters
+Parser accuracy is the biggest adoption ceiling for more complex or mature repositories.
 
 ### Acceptance Criteria
-- Parser resolves more real-world targets/dependencies than current static-only behavior.
-- Fallback path exists when external `make` metadata fails.
-- Performance remains acceptable on medium/large Makefiles.
-- Compatibility metrics are tracked in tests.
+- Parser resolves more real-world targets and dependencies than the current static-only approach.
+- Fallback path exists when `make` metadata inspection fails.
+- Performance remains acceptable on medium and large Makefiles.
+- The trust model is documented.
 
-## 12) Compatibility fixture suite for complex Makefiles
+### Dependencies
+- None
+
+### 7) Add compatibility fixture suite for complex Makefiles
 
 - Milestone: `v0.6.0`
 - Labels: `testing`, `area:parser`, `priority:P1`
 
 ### Summary
-Add fixture-based tests covering complex Makefile patterns from real projects.
+Create a fixture-based compatibility test suite from real Makefile patterns.
+
+### Why this matters
+Parser work needs product-level regression protection, not only unit-level correctness.
 
 ### Acceptance Criteria
-- Fixtures include includes, conditional blocks, pattern rules, and target-specific vars.
-- Expected target/dependency snapshots are versioned in tests.
-- CI runs fixture suite on every parser-related change.
-- Failures show clear diff for target graph regressions.
+- Fixtures include `include`, conditionals, pattern rules, and target-specific variables.
+- Expected target and dependency snapshots are versioned in tests.
+- CI runs the fixture suite on parser changes.
+- Failures show useful diffs.
+
+### Dependencies
+- Parser v2
+
+### 8) Surface parser confidence and unsupported constructs in the UI
+
+- Milestone: `v0.6.0`
+- Labels: `enhancement`, `area:parser`, `area:tui`, `priority:P1`
+
+### Summary
+Make parser uncertainty visible instead of silently presenting incomplete information as fully trusted.
+
+### Why this matters
+Trust is product-critical. Clear warnings are better than polished but misleading output.
+
+### Acceptance Criteria
+- UI can show when parsing is partial, degraded, or metadata-assisted.
+- Unsupported constructs produce understandable hints.
+- Warnings do not block normal workflows unless execution would be misleading.
+
+### Dependencies
+- Parser v2
+
+### 9) Improve support for included and generated Makefiles
+
+- Milestone: `v0.6.0`
+- Labels: `enhancement`, `area:parser`, `priority:P1`
+
+### Summary
+Improve discovery and modeling of targets that come from included files or generated Makefile fragments.
+
+### Why this matters
+This is a common source of "missing target" confusion in real projects.
+
+### Acceptance Criteria
+- Included files are represented more accurately in parsing results.
+- Generated or external dependencies degrade gracefully when full resolution is impossible.
+- Docs explain supported and unsupported cases.
+
+### Dependencies
+- Parser v2
+
+## `v0.7.0` Team and CI Workflows
+
+### 10) Export dependency graphs to DOT and Mermaid
+
+- Milestone: `v0.7.0`
+- Labels: `enhancement`, `area:graph`, `priority:P1`
+
+### Summary
+Add graph export formats that teams can reuse in docs, PRs, and CI artifacts.
+
+### Why this matters
+It extends lazymake beyond the local TUI and strengthens onboarding and architecture communication.
+
+### Acceptance Criteria
+- Export graph to DOT format.
+- Export graph to Mermaid format.
+- Exports include cycle and missing dependency annotations where relevant.
+- CLI and documentation are included.
+
+### Dependencies
+- None
+
+### 11) Add headless CLI outputs for targets, variables, and graph metadata
+
+- Milestone: `v0.7.0`
+- Labels: `enhancement`, `area:cli`, `area:parser`, `priority:P1`
+
+### Summary
+Expose selected lazymake insights through machine-readable CLI commands.
+
+### Why this matters
+Teams should be able to use lazymake in scripts, docs generation, and CI checks.
+
+### Acceptance Criteria
+- CLI can output target metadata in JSON.
+- CLI can output graph metadata in JSON or another machine-readable format.
+- CLI can output variable metadata in JSON.
+- Commands reuse the same parsing rules as the TUI.
+
+### Dependencies
+- Parser v2
+
+### 12) Add preset import/export for team sharing
+
+- Milestone: `v0.7.0`
+- Labels: `enhancement`, `area:tui`, `area:history`, `priority:P2`
+
+### Summary
+Allow presets to be shared across teammates or checked into project-level configuration.
+
+### Why this matters
+This turns personal convenience into team workflow standardization.
+
+### Acceptance Criteria
+- Presets can be exported and imported in a documented format.
+- Team-shared presets can coexist with personal presets.
+- Merge and override behavior is explicit.
+
+### Dependencies
+- Saved run presets
+
+## `v0.8.0` Intelligence
+
+### 13) Add run diff between current and previous executions
+
+- Milestone: `v0.8.0`
+- Labels: `enhancement`, `area:history`, `area:tui`, `priority:P1`
+
+### Summary
+Help users compare the latest run with the previous one, including parameters, duration, and output changes.
+
+### Why this matters
+This is a practical debugging feature that increases the value of historical data.
+
+### Acceptance Criteria
+- User can compare at least the two most recent executions of a target.
+- Diff highlights parameter changes and major output changes.
+- Works for both successful and failed runs.
+
+### Dependencies
+- Parameterized execution
+
+### 14) Add richer performance insights and bottleneck hints
+
+- Milestone: `v0.8.0`
+- Labels: `enhancement`, `area:history`, `area:graph`, `priority:P2`
+
+### Summary
+Use historical and graph data to surface slow targets, likely bottlenecks, and parallelization opportunities.
+
+### Why this matters
+lazymake already stores useful execution context; the next step is to convert it into guidance.
+
+### Acceptance Criteria
+- UI can identify consistently slow targets.
+- Product can point out possible parallelism or critical-path bottlenecks.
+- Insights are visible but non-intrusive.
+
+### Dependencies
+- Parser v2
+- Stable execution history
+
+### 15) Add smart target grouping based on usage and risk
+
+- Milestone: `v0.8.0`
+- Labels: `enhancement`, `area:tui`, `priority:P2`
+
+### Summary
+Group targets dynamically by signals such as frequent use, danger level, recent failure, or regression risk.
+
+### Why this matters
+This makes the product feel more adaptive without changing the underlying Makefile model.
+
+### Acceptance Criteria
+- User can browse grouped views such as recent, risky, slow, or failed.
+- Grouping logic is understandable and does not hide targets.
+- Default view remains simple for new users.
+
+### Dependencies
+- Stable history and performance data

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -1,0 +1,250 @@
+# Product Roadmap
+
+This document translates the current state of lazymake into a product roadmap.
+It is intentionally opinionated: the goal is not to list every possible idea, but to prioritize the work that most increases product value.
+
+## Current Product Position
+
+lazymake is already more than a target picker:
+
+- It helps users discover Makefile targets quickly
+- It explains execution through graphs, recipe previews, and variable inspection
+- It reduces risk through dangerous command detection
+- It improves repeat workflows with history, performance tracking, workspace switching, export, and shell integration
+
+In product terms, the core promise is:
+
+> "Make unfamiliar or large Makefile-based workflows easier to understand, safer to run, and faster to repeat."
+
+That promise is strong, but there are still two gaps:
+
+1. **Execution control gap**
+Users can run targets, but they still lack pre-run controls such as dry-run, runtime flags, environment variables, and reusable presets.
+
+2. **Compatibility gap**
+The parser is still mostly static and line-based. That is enough for many Makefiles, but complex real-world Makefiles will be the main adoption ceiling.
+
+## Product Strategy
+
+The next stage of lazymake should focus on four layers, in order:
+
+1. **Safe Execution**
+Make execution more previewable, parameterized, and repeatable.
+
+2. **Compatibility**
+Support more real-world Makefiles without surprising omissions or incorrect graphs.
+
+3. **Team and CI Workflows**
+Make lazymake useful not only in the TUI, but also in docs, onboarding, and automation.
+
+4. **Intelligence**
+Turn historical usage and execution data into meaningful guidance, not just storage.
+
+## Roadmap Principles
+
+- Prioritize features that reduce fear and ambiguity before features that add novelty
+- Prefer workflows that fit existing `make` habits over introducing custom abstractions
+- Treat parser accuracy as a growth bottleneck, not just a technical nicety
+- Make every new execution feature testable and explicit in the UI
+- Keep graceful degradation as a product rule
+
+## Detailed Roadmap
+
+### Phase 1: `v0.5` Safe Execution
+
+**Theme:** "Understand before you run, and reuse what works."
+
+**Why this phase first**
+
+This is the highest-leverage product move. Users already trust lazymake enough to browse targets. The next step is to make it the preferred place to launch them.
+
+**Primary outcomes**
+
+- Users can preview target behavior before execution
+- Users can pass temporary runtime context safely
+- Users can quickly repeat known-good executions
+- Repeated workflows become a first-class product concept
+
+**Planned features**
+
+1. Dry-run / explain mode
+2. Interactive execution parameters (`ENV` variables and make flags)
+3. Saved presets per target and Makefile
+4. Rerun last execution with previous parameters
+5. TUI flow tests for execution variants and side-effect behavior
+
+**Definition of done for the phase**
+
+- Dry-run is visible, safe, and does not pollute history/export/shell integration
+- Parameter entry is deterministic and cancelable
+- Presets survive restart and are easy to reapply
+- Re-run is a one-keystroke path for common workflows
+- Core execution flows have automated tests
+
+**Product risks**
+
+- Added pre-run UI can make the TUI feel heavier
+- Too much flexibility in flags/env can create confusing edge cases
+
+**Mitigation**
+
+- Keep default Enter behavior fast
+- Make advanced options opt-in
+- Use explicit view labels and confirmation text
+
+### Phase 2: `v0.6` Compatibility
+
+**Theme:** "If the Makefile is real, lazymake should still be useful."
+
+**Why this phase second**
+
+Once users depend on lazymake for execution, parser limitations become much more visible. Compatibility work unlocks broader adoption in monorepos and mature build systems.
+
+**Primary outcomes**
+
+- Better target discovery and dependency accuracy on complex Makefiles
+- Fewer incorrect graphs, missing targets, and misleading previews
+- Clearer trust model when static parsing is incomplete
+
+**Planned features**
+
+1. Parser v2 using a hybrid model with `make` metadata
+2. Compatibility fixture suite for complex Makefiles
+3. Parser confidence warnings and unsupported-construct hints
+4. More robust support for `include`, conditionals, pattern rules, and target-specific variables
+
+**Definition of done for the phase**
+
+- Parser v2 improves compatibility on a representative fixture corpus
+- Failures degrade clearly instead of silently misleading users
+- Compatibility regressions are caught in CI
+
+**Product risks**
+
+- External `make` inspection can be slower or environment-sensitive
+- Some Makefiles remain impossible to model perfectly without execution
+
+**Mitigation**
+
+- Keep a fallback static path
+- Measure parse time and expose warnings when needed
+
+### Phase 3: `v0.7` Team and CI
+
+**Theme:** "Make lazymake outputs reusable outside the TUI."
+
+**Why this phase third**
+
+After execution and compatibility are stronger, the next best move is to let the tool serve documentation, onboarding, and automation use cases.
+
+**Primary outcomes**
+
+- Graphs and target metadata can move into docs and CI artifacts
+- Teams can standardize common executions
+- lazymake becomes useful in headless workflows too
+
+**Planned features**
+
+1. Export dependency graph to DOT and Mermaid
+2. Headless CLI output for targets, variables, and graph metadata in machine-readable formats
+3. Preset import/export for team sharing
+4. Copy/share flows for commands and graph views
+
+**Definition of done for the phase**
+
+- Teams can generate graph artifacts without opening the TUI
+- CI and docs use cases are documented and stable
+- Presets can be shared without manual file surgery
+
+**Product risks**
+
+- CLI scope can sprawl beyond the product's center
+
+**Mitigation**
+
+- Only add headless commands that reinforce the same understanding and execution model
+
+### Phase 4: `v0.8` Intelligence
+
+**Theme:** "Use history to guide better decisions."
+
+**Why this phase last**
+
+This phase compounds value from previous work. It becomes much stronger once executions are parameterized, repeated, and better modeled.
+
+**Primary outcomes**
+
+- Users can see what changed between runs
+- Slow or risky targets become easier to notice
+- The product starts surfacing actionable advice
+
+**Planned features**
+
+1. Run diff between current and previous executions
+2. Smarter performance insights and trend views
+3. Recommendations around parallelism and likely bottlenecks
+4. Richer target grouping such as frequent, risky, slow, and recently failed
+
+**Definition of done for the phase**
+
+- Historical data helps users make faster choices, not just inspect logs
+- Insights are visible but non-intrusive
+
+## Suggested Milestone Map
+
+### `v0.5`
+
+- Dry-run / explain mode
+- Execution parameters
+- Saved presets
+- Rerun last
+- TUI flow tests
+
+### `v0.6`
+
+- Parser v2
+- Compatibility fixtures
+- Parser confidence UI
+- Extended Makefile construct support
+
+### `v0.7`
+
+- Graph export to DOT and Mermaid
+- Headless CLI outputs
+- Preset sharing
+- Command and graph sharing
+
+### `v0.8`
+
+- Run diff
+- Richer performance analytics
+- Parallelism suggestions
+- Smart target grouping
+
+## Success Metrics
+
+These metrics are the most useful ones to watch after each phase:
+
+- Share of executions initiated via lazymake instead of manual shell commands
+- Reuse rate of presets and rerun flows
+- Parser compatibility rate on fixture corpus
+- Number of successful graph exports / headless CLI use cases
+- Reduction in failed or canceled dangerous executions
+- Median time from app launch to target execution
+
+## What Not to Prioritize Yet
+
+- Full Makefile editing inside the TUI
+- A plugin ecosystem before the core execution and compatibility story matures
+- Heavy visual redesign without a product problem to solve
+- Replacing `make` semantics with custom abstractions
+
+## Product Owner Recommendation
+
+If only three bets can be funded next, they should be:
+
+1. Dry-run / explain mode
+2. Interactive execution parameters plus presets
+3. Parser v2 with a compatibility fixture suite
+
+Together, those three move lazymake from a strong interface into a dependable execution surface for serious projects.


### PR DESCRIPTION
## Summary
- add a detailed product roadmap under `docs/product-roadmap.md`
- refresh `docs/github-issues-backlog.md` to focus on open post-0.4 work
- link the new planning docs from `docs/README.md`
- create and align the first five `v0.5.0` issues on GitHub (#34, #35, #36, #37, #38)

## Testing
- `make lint` currently fails for this docs-only change set with: `no go files to analyze`

## Notes
- docs-only PR
- no code behavior changes