### PR TITLE
feat: interactive execution parameters (#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Dry-run mode (#38): preview target execution via `make -n` without running the recipe. Activate session-wide via the `--dry-run` CLI flag or `dry_run: true` in `.lazymake.yaml`. CLI flag overrides the config. Dangerous-target confirmation still fires; history, exports, and shell integration entries are skipped. A `DRY-RUN` badge in the status bar and `make -n` in the executing/output headers indicate the active mode.
+- Interactive execution parameters (#37): press `e` on a target in the list to open a pre-run form for setting per-execution environment variables (`KEY=value` pairs, quoted values supported) and make flags (e.g. `-j4 -k --always-make`). Tab toggles focus between the two fields, Enter runs, Esc cancels without side effects. Parameters are echoed in the executing/output header and recorded in history and export entries. Dangerous targets still go through confirmation after the form. The last-used parameters per target are remembered for the current session.
+
+### Changed
+
+- `executor.ExecuteStreaming` now takes an `ExecutionOptions` struct instead of a `dryRun bool`. Callers outside the TUI must migrate to the new signature.
 
 ## [0.4.1] - 2026-03-27
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ lazymake provides an interactive interface for Makefiles with:
 - **Syntax highlighting** for recipes (detects Python, Go, shell scripts, etc.)
 - **Safety warnings** for destructive commands (configurable)
 - **Dry-run mode** (`--dry-run`) — preview commands via `make -n` without side effects
+- **Interactive execution parameters** — press `e` to set env vars and make flags per run
 - **Performance tracking** to identify slow targets
 
 
@@ -70,6 +71,7 @@ lazymake --dry-run
 
 - `↑/↓` or `j/k` - Navigate
 - `Enter` - Execute selected target
+- `e` - Run with env vars and make flags (opens parameters form)
 - `g` - Show dependency graph
 - `v` - Open variable inspector
 - `w` - Switch between Makefiles (workspace picker)

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ This directory contains detailed guides and feature documentation to help you ge
 - [Recent History & Smart Search](features/history-search.md) - Fast access to frequently used targets
 - [Workspace Management](features/workspace-management.md) - Work with multiple Makefiles across projects
 - [Performance Profiling](features/performance-tracking.md) - Track execution times and detect regressions
+- [Interactive Execution Parameters](features/execution-parameters.md) - Run a target with custom env vars and make flags
 - [Export & Shell Integration](features/export-shell-integration.md) - Export results and integrate with shell history
 
 ## Product Planning

--- a/docs/features/execution-parameters.md
+++ b/docs/features/execution-parameters.md
@@ -1,0 +1,66 @@
+# Interactive execution parameters
+
+Lazymake can launch a target with per-execution environment variables and make
+flags without forcing you to drop back to the shell. This is useful for
+workflows that look like `ENV=prod make deploy -j4` rather than a plain `make
+build`.
+
+## Opening the form
+
+From the target list, place the cursor on the target you want to run and press
+`e` (Edit & Run). A modal opens with two fields:
+
+- **ENV** — whitespace-separated `KEY=value` pairs. Quote values that contain
+  spaces: `MSG="hello world"`.
+- **FLAGS** — whitespace-separated make flags, e.g. `-j4 -k --always-make`.
+  Every token must start with `-`; if you accidentally type a `KEY=value`
+  here, lazymake will tell you to move it to the env field instead.
+
+Switch fields with `Tab` / `Shift+Tab`. Press `Enter` to run, `Esc` to cancel
+without any side effects.
+
+## What gets recorded
+
+- The executing screen header shows `make -n` (in dry-run) or `make`, the
+  target name, and your env+flags so you can verify the invocation before
+  output starts streaming.
+- The output view header shows the same params so you can come back to a
+  previous run and remember what was applied.
+- Execution history (`~/.cache/lazymake/history.json`) stores env and flags
+  alongside the timing record under `recent_executions[].env` and
+  `recent_executions[].flags`. The fields are omitted when no parameters were
+  used, so plain runs serialize exactly as before.
+- Export records (when export is enabled) include `env` and `flags` fields in
+  the JSON output and `Env:` / `Flags:` lines in the human-readable log.
+
+## Session memory
+
+When you submit the form, lazymake caches the parsed env and flags per target
+**for the current session**. Reopening the form on the same target pre-fills
+the previous values so you can re-run with a small edit. The cache is in
+memory only — restart and the values are forgotten. Persistent presets are
+tracked separately under issue #38.
+
+## Interaction with other features
+
+- **Dry-run** (`--dry-run`): if the session is in dry-run mode, your flags are
+  combined with `-n`, e.g. `make -n -j4 build`. History, exports, and shell
+  integration entries are still skipped, matching the dry-run behavior for
+  plain runs.
+- **Dangerous targets**: the form opens first, then the existing confirmation
+  dialog. This lets you see exactly what env+flags will be applied before
+  approving the dangerous command.
+- **Quick run**: `Enter` (without the form) still works as before — it runs
+  the target with no extra env vars and no flags.
+
+## Safety notes
+
+- Commands are assembled with `exec.CommandContext("make", args...)`. No shell
+  is involved, so values are not subject to shell metacharacter
+  interpretation. `MSG="hi; rm -rf /"` is delivered to make as a literal
+  string, not interpreted.
+- Env keys must match `[A-Za-z_][A-Za-z0-9_]*`. Make-style variable overrides
+  like `VAR=value` passed on the make CLI are intentionally not supported in
+  the flags field — put them in env instead.
+- Env keys are sorted before the process is launched, so identical input
+  always produces the same `make` invocation, useful for reproducing runs.

--- a/docs/guides/keyboard-shortcuts.md
+++ b/docs/guides/keyboard-shortcuts.md
@@ -9,6 +9,7 @@ Complete reference of all keyboard shortcuts in lazymake, organized by view.
 | `↑` / `↓` | Navigate up/down through targets |
 | `j` / `k` | Vim-style navigation (up/down) |
 | `Enter` | Execute the selected target |
+| `e` | Run the selected target with env vars and make flags (opens parameters form) |
 | `g` | View dependency graph for selected target |
 | `v` | Open variable inspector |
 | `w` | Open workspace picker to switch Makefiles |
@@ -72,6 +73,20 @@ Complete reference of all keyboard shortcuts in lazymake, organized by view.
 | `?` | Return to list view |
 | `Esc` | Return to list view |
 | `q` | Quit lazymake |
+| `Ctrl+C` | Quit lazymake |
+
+## Run Parameters Form
+
+Opened from the main list with `e` to set per-execution env vars and make flags
+(see [Interactive execution parameters](../features/execution-parameters.md)).
+
+| Key | Action |
+|-----|--------|
+| Type characters | Edit the focused field (env or flags) |
+| `Tab` | Switch focus between the env and flags fields |
+| `Shift+Tab` | Switch focus (reverse) |
+| `Enter` | Validate inputs and run the target |
+| `Esc` | Cancel and return to the list with no side effects |
 | `Ctrl+C` | Quit lazymake |
 
 ## Search/Filter Mode

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"context"
 	"io"
+	"os"
 	"os/exec"
+	"sort"
 	"sync"
 	"time"
 )
@@ -54,28 +56,87 @@ type OutputChunk struct {
 	Err  error
 }
 
-// ExecuteStreaming runs a make target and streams output via channel.
-// When dryRun is true, the command is invoked with `make -n`, which prints
-// the recipe lines that would have been executed without actually running them.
-// Returns: channel for output chunks, cancel function.
+// ExecutionOptions controls how ExecuteStreaming invokes `make`.
 //
-// TODO(#93): replace dryRun bool with an ExecutionOptions struct once
-// interactive execution parameters (env vars, make flags) land.
-func ExecuteStreaming(target, makefilePath string, dryRun bool) (<-chan OutputChunk, func()) {
+// All fields are optional. The zero value is equivalent to a normal,
+// no-extra-env, no-extra-flags execution.
+type ExecutionOptions struct {
+	// DryRun adds `-n` (`--just-print`) so make prints recipe lines
+	// without actually running them.
+	DryRun bool
+
+	// Env are additional environment variables applied on top of
+	// os.Environ() in the spawned process. Make picks them up the same
+	// way as a regular shell would. Keys are sorted before applying
+	// so command construction is deterministic.
+	Env map[string]string
+
+	// Flags are extra arguments inserted between the makefile path and
+	// the target, e.g. ["-j4", "-k"]. They are passed through exec
+	// argv (not the shell), so no escaping is performed and no shell
+	// metacharacters are interpreted.
+	Flags []string
+}
+
+// buildArgs constructs the argv (excluding the leading "make") for the
+// given options and target. Order is:
+//
+//	-f <makefilePath> [-n] [user flags...] <target>
+//
+// `-n` is injected before user flags so users can still override or
+// extend dry-run with additional flags like `-j1`.
+func buildArgs(target, makefilePath string, opts ExecutionOptions) []string {
+	args := make([]string, 0, 3+len(opts.Flags))
+	args = append(args, "-f", makefilePath)
+	if opts.DryRun {
+		// `-n` (--just-print / --dry-run): print recipe commands without executing them.
+		// MAKEFLAGS propagates -n to recursive sub-makes automatically.
+		args = append(args, "-n")
+	}
+	args = append(args, opts.Flags...)
+	args = append(args, target)
+	return args
+}
+
+// buildEnv returns the environment for the spawned process: os.Environ()
+// plus opts.Env, with deterministic ordering (keys sorted). Returns nil
+// when opts.Env is empty so cmd.Env can stay at the os/exec default.
+func buildEnv(opts ExecutionOptions) []string {
+	if len(opts.Env) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(opts.Env))
+	for k := range opts.Env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	env := os.Environ()
+	for _, k := range keys {
+		env = append(env, k+"="+opts.Env[k])
+	}
+	return env
+}
+
+// ExecuteStreaming runs a make target and streams output via channel.
+//
+// Options control dry-run mode, additional environment variables, and
+// extra make flags. The command is invoked via exec argv (no shell), so
+// values are not subject to shell interpretation.
+//
+// Returns: channel for output chunks, cancel function.
+func ExecuteStreaming(target, makefilePath string, opts ExecutionOptions) (<-chan OutputChunk, func()) {
 	chunks := make(chan OutputChunk, 100)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	go func() {
 		defer close(chunks)
 
-		args := []string{"-f", makefilePath}
-		if dryRun {
-			// `-n` (--just-print / --dry-run): print recipe commands without executing them.
-			// MAKEFLAGS propagates -n to recursive sub-makes automatically.
-			args = append(args, "-n")
-		}
-		args = append(args, target)
+		args := buildArgs(target, makefilePath, opts)
 		cmd := exec.CommandContext(ctx, "make", args...)
+		if env := buildEnv(opts); env != nil {
+			cmd.Env = env
+		}
 
 		// Create pipes for stdout and stderr
 		stdout, err := cmd.StdoutPipe()

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -548,7 +548,7 @@ func TestExecuteStreamingDryRun(t *testing.T) {
 	defer os.Chdir(oldDir)
 	os.Chdir(tempDir)
 
-	chunks, _ := ExecuteStreaming("touch-sentinel", makefile, true)
+	chunks, _ := ExecuteStreaming("touch-sentinel", makefile, ExecutionOptions{DryRun: true})
 
 	// Drain the channel and concatenate streamed output.
 	var output string
@@ -587,7 +587,7 @@ func TestExecuteStreamingNormalRunsCommands(t *testing.T) {
 	defer os.Chdir(oldDir)
 	os.Chdir(tempDir)
 
-	chunks, _ := ExecuteStreaming("touch-sentinel", makefile, false)
+	chunks, _ := ExecuteStreaming("touch-sentinel", makefile, ExecutionOptions{})
 	for chunk := range chunks {
 		if chunk.Done && chunk.Err != nil {
 			t.Fatalf("unexpected error from normal run: %v", chunk.Err)
@@ -596,6 +596,164 @@ func TestExecuteStreamingNormalRunsCommands(t *testing.T) {
 
 	if _, err := os.Stat(sentinel); err != nil {
 		t.Errorf("expected sentinel file to exist after normal run, got: %v", err)
+	}
+}
+
+// TestBuildArgs verifies argv construction for ExecuteStreaming.
+//
+// The order matters: `-f <path>` first, then `-n` (if dry-run), then user
+// flags, then the target last. User code relies on this for predictable
+// behavior — see docs/features/execution-parameters.md.
+func TestBuildArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		opts ExecutionOptions
+		want []string
+	}{
+		{
+			name: "zero options",
+			opts: ExecutionOptions{},
+			want: []string{"-f", "Makefile", "build"},
+		},
+		{
+			name: "dry-run only",
+			opts: ExecutionOptions{DryRun: true},
+			want: []string{"-f", "Makefile", "-n", "build"},
+		},
+		{
+			name: "flags only",
+			opts: ExecutionOptions{Flags: []string{"-j4", "-k"}},
+			want: []string{"-f", "Makefile", "-j4", "-k", "build"},
+		},
+		{
+			name: "dry-run + flags: -n precedes user flags",
+			opts: ExecutionOptions{DryRun: true, Flags: []string{"-j4"}},
+			want: []string{"-f", "Makefile", "-n", "-j4", "build"},
+		},
+		{
+			name: "env does not appear in argv",
+			opts: ExecutionOptions{Env: map[string]string{"FOO": "bar"}},
+			want: []string{"-f", "Makefile", "build"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildArgs("build", "Makefile", tt.opts)
+			if len(got) != len(tt.want) {
+				t.Fatalf("args length: got %d %v, want %d %v", len(got), got, len(tt.want), tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("args[%d]: got %q, want %q (full: %v)", i, got[i], tt.want[i], got)
+				}
+			}
+		})
+	}
+}
+
+// TestBuildEnv verifies env construction. Keys must be sorted so the
+// resulting argv-equivalent string is deterministic (helpful for testing
+// and for users reading the output).
+func TestBuildEnv(t *testing.T) {
+	t.Run("nil when empty", func(t *testing.T) {
+		if got := buildEnv(ExecutionOptions{}); got != nil {
+			t.Errorf("expected nil for empty env, got %v", got)
+		}
+	})
+
+	t.Run("keys appended in sorted order", func(t *testing.T) {
+		opts := ExecutionOptions{Env: map[string]string{
+			"ZETA":  "z",
+			"ALPHA": "a",
+			"BETA":  "b",
+		}}
+		env := buildEnv(opts)
+		if env == nil {
+			t.Fatal("expected non-nil env")
+		}
+		// The last three entries are our additions, in sorted-by-key order.
+		got := env[len(env)-3:]
+		want := []string{"ALPHA=a", "BETA=b", "ZETA=z"}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("env[%d]: got %q, want %q", i, got[i], want[i])
+			}
+		}
+	})
+
+	t.Run("includes os.Environ", func(t *testing.T) {
+		t.Setenv("LAZYMAKE_TEST_MARKER", "yes")
+		opts := ExecutionOptions{Env: map[string]string{"EXTRA": "1"}}
+		env := buildEnv(opts)
+		found := false
+		for _, e := range env {
+			if e == "LAZYMAKE_TEST_MARKER=yes" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("expected os.Environ to be merged into result")
+		}
+	})
+}
+
+// TestExecuteStreaming_EnvIsPassedToMake verifies env vars actually reach
+// the spawned make process by echoing the variable from a recipe.
+func TestExecuteStreaming_EnvIsPassedToMake(t *testing.T) {
+	tempDir := t.TempDir()
+	makefile := tempDir + "/Makefile"
+
+	makefileContent := `.PHONY: show-env
+show-env:
+	@echo "GREETING=$(GREETING)"
+`
+	if err := os.WriteFile(makefile, []byte(makefileContent), 0644); err != nil {
+		t.Fatalf("Failed to create test Makefile: %v", err)
+	}
+
+	chunks, _ := ExecuteStreaming(
+		"show-env",
+		makefile,
+		ExecutionOptions{Env: map[string]string{"GREETING": "hello"}},
+	)
+
+	var output string
+	for chunk := range chunks {
+		output += chunk.Data
+	}
+
+	if !contains(output, "GREETING=hello") {
+		t.Errorf("expected output to contain GREETING=hello, got: %q", output)
+	}
+}
+
+// TestExecuteStreaming_FlagsReachMake passes `-n` via opts.Flags (not
+// opts.DryRun) and confirms make still prints rather than runs. This
+// is the closest "user flag was honored" check we can do without
+// reaching into argv.
+func TestExecuteStreaming_FlagsReachMake(t *testing.T) {
+	tempDir := t.TempDir()
+	makefile := tempDir + "/Makefile"
+	sentinel := tempDir + "/flags-sentinel"
+
+	makefileContent := ".PHONY: touch-it\ntouch-it:\n\ttouch " + sentinel + "\n"
+	if err := os.WriteFile(makefile, []byte(makefileContent), 0644); err != nil {
+		t.Fatalf("Failed to create test Makefile: %v", err)
+	}
+
+	chunks, _ := ExecuteStreaming(
+		"touch-it",
+		makefile,
+		ExecutionOptions{Flags: []string{"-n"}},
+	)
+	for chunk := range chunks {
+		_ = chunk
+	}
+
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Errorf("flag -n via opts.Flags should have prevented sentinel creation, stat: %v", err)
 	}
 }
 

--- a/internal/export/record.go
+++ b/internal/export/record.go
@@ -4,12 +4,37 @@ import (
 	"fmt"
 	"os"
 	"os/user"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/rshelekhov/lazymake/internal/executor"
 	"github.com/rshelekhov/lazymake/version"
 )
+
+// formatEnvForLog renders env pairs deterministically as
+// "KEY=val KEY2=val2", values quoted if they contain whitespace.
+// Used by FormatLog so consecutive runs with the same env produce
+// identical strings.
+func formatEnvForLog(env map[string]string) string {
+	if len(env) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		v := env[k]
+		if strings.ContainsAny(v, " \t") {
+			v = `"` + v + `"`
+		}
+		parts = append(parts, k+"="+v)
+	}
+	return strings.Join(parts, " ")
+}
 
 // ExecutionRecord represents a complete execution result for export
 type ExecutionRecord struct {
@@ -30,6 +55,12 @@ type ExecutionRecord struct {
 	Output       string `json:"output"`
 	ErrorMessage string `json:"error_message,omitempty"`
 
+	// Run parameters supplied via the interactive form (issue #37).
+	// Omitted from JSON when empty so plain runs serialize identically
+	// to previous versions of the format.
+	Env   map[string]string `json:"env,omitempty"`
+	Flags []string          `json:"flags,omitempty"`
+
 	// Environment context
 	WorkingDir      string `json:"working_dir"`
 	User            string `json:"user,omitempty"`
@@ -37,8 +68,17 @@ type ExecutionRecord struct {
 	LazymakeVersion string `json:"lazymake_version,omitempty"`
 }
 
-// NewExecutionRecord creates an ExecutionRecord from execution data
+// NewExecutionRecord creates an ExecutionRecord from execution data.
+// Env and flags default to empty; use NewExecutionRecordWithParams
+// to record interactive-form parameters (issue #37).
 func NewExecutionRecord(makefilePath, targetName string, result executor.Result) *ExecutionRecord {
+	return NewExecutionRecordWithParams(makefilePath, targetName, result, nil, nil)
+}
+
+// NewExecutionRecordWithParams is the full-fidelity factory. env and
+// flags may be nil for plain runs; both are emitted in JSON output
+// only when non-empty.
+func NewExecutionRecordWithParams(makefilePath, targetName string, result executor.Result, env map[string]string, flags []string) *ExecutionRecord {
 	// Get working directory
 	workingDir, _ := os.Getwd()
 
@@ -69,6 +109,8 @@ func NewExecutionRecord(makefilePath, targetName string, result executor.Result)
 		ExitCode:        result.ExitCode,
 		Output:          result.Output,
 		ErrorMessage:    errMsg,
+		Env:             env,
+		Flags:           flags,
 		WorkingDir:      workingDir,
 		User:            currentUser,
 		Hostname:        hostname,
@@ -105,6 +147,14 @@ func (r *ExecutionRecord) FormatLog() string {
 	}
 	if r.Hostname != "" {
 		fmt.Fprintf(&b, "Host:          %s\n", r.Hostname)
+	}
+
+	// Interactive run parameters, when present (issue #37).
+	if len(r.Env) > 0 {
+		fmt.Fprintf(&b, "Env:           %s\n", formatEnvForLog(r.Env))
+	}
+	if len(r.Flags) > 0 {
+		fmt.Fprintf(&b, "Flags:         %s\n", strings.Join(r.Flags, " "))
 	}
 
 	// Output section

--- a/internal/export/record_params_test.go
+++ b/internal/export/record_params_test.go
@@ -1,0 +1,92 @@
+package export
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rshelekhov/lazymake/internal/executor"
+)
+
+// TestNewExecutionRecordWithParams asserts that params (env + flags)
+// supplied by the interactive form (issue #37) are stored on the
+// record and not silently dropped.
+func TestNewExecutionRecordWithParams(t *testing.T) {
+	res := executor.Result{
+		Duration:  100 * time.Millisecond,
+		StartTime: time.Now(),
+		EndTime:   time.Now(),
+		ExitCode:  0,
+	}
+	env := map[string]string{"FOO": "bar"}
+	flags := []string{"-j4"}
+
+	rec := NewExecutionRecordWithParams("/Makefile", "build", res, env, flags)
+	if rec.Env["FOO"] != "bar" {
+		t.Errorf("env: got %v, want FOO=bar", rec.Env)
+	}
+	if len(rec.Flags) != 1 || rec.Flags[0] != "-j4" {
+		t.Errorf("flags: got %v, want [-j4]", rec.Flags)
+	}
+}
+
+// TestNewExecutionRecordDefaultsEmpty makes sure the convenience
+// NewExecutionRecord constructor keeps env/flags nil. JSON omitempty
+// then prevents the legacy export shape from changing.
+func TestNewExecutionRecordDefaultsEmpty(t *testing.T) {
+	res := executor.Result{
+		Duration:  100 * time.Millisecond,
+		StartTime: time.Now(),
+		EndTime:   time.Now(),
+	}
+	rec := NewExecutionRecord("/Makefile", "build", res)
+	if rec.Env != nil {
+		t.Errorf("expected nil env from legacy constructor, got %v", rec.Env)
+	}
+	if rec.Flags != nil {
+		t.Errorf("expected nil flags from legacy constructor, got %v", rec.Flags)
+	}
+}
+
+// TestFormatLogIncludesParams verifies the human-readable log contains
+// the Env and Flags lines when present, sorted deterministically.
+func TestFormatLogIncludesParams(t *testing.T) {
+	rec := &ExecutionRecord{
+		TargetName: "deploy",
+		Timestamp:  time.Now(),
+		Output:     "ok\n",
+		Env:        map[string]string{"B": "2", "A": "1", "MSG": "hello world"},
+		Flags:      []string{"-j4", "-k"},
+	}
+	got := rec.FormatLog()
+	if !strings.Contains(got, "Env:") {
+		t.Error("expected Env: line in log")
+	}
+	if !strings.Contains(got, "Flags:") {
+		t.Error("expected Flags: line in log")
+	}
+	// Sorted: A first, then B, then MSG.
+	if !strings.Contains(got, `A=1 B=2 MSG="hello world"`) {
+		t.Errorf("env not formatted as expected (sorted, quoted-with-spaces):\n%s", got)
+	}
+	if !strings.Contains(got, "-j4 -k") {
+		t.Errorf("flags not formatted as expected:\n%s", got)
+	}
+}
+
+// TestFormatLogOmitsParamsWhenEmpty confirms the Env/Flags lines do not
+// appear for plain runs.
+func TestFormatLogOmitsParamsWhenEmpty(t *testing.T) {
+	rec := &ExecutionRecord{
+		TargetName: "build",
+		Timestamp:  time.Now(),
+		Output:     "ok\n",
+	}
+	got := rec.FormatLog()
+	if strings.Contains(got, "Env:") {
+		t.Error("Env: should not appear for runs without env")
+	}
+	if strings.Contains(got, "Flags:") {
+		t.Error("Flags: should not appear for runs without flags")
+	}
+}

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -17,10 +17,17 @@ const (
 )
 
 // ExecutionRecord represents a single target execution with timing
+//
+// Env and Flags are recorded when the run was launched via the
+// interactive parameters form (issue #37). Both are omitted from JSON
+// when empty so existing on-disk history files stay byte-identical for
+// runs that didn't use parameters.
 type ExecutionRecord struct {
-	Duration  time.Duration `json:"duration"`
-	Timestamp time.Time     `json:"timestamp"`
-	Success   bool          `json:"success"`
+	Duration  time.Duration     `json:"duration"`
+	Timestamp time.Time         `json:"timestamp"`
+	Success   bool              `json:"success"`
+	Env       map[string]string `json:"env,omitempty"`
+	Flags     []string          `json:"flags,omitempty"`
 }
 
 // Entry represents a single target execution record
@@ -116,6 +123,14 @@ func (h *History) RecordExecution(makefilePath, targetName string) {
 // Implements LRU eviction: keeps only the maxRecentTargets most recent targets
 // Implements execution history LRU: keeps only the maxRecentExecutions most recent executions
 func (h *History) RecordExecutionWithTiming(makefilePath, targetName string, duration time.Duration, success bool) {
+	h.RecordExecutionWithParams(makefilePath, targetName, duration, success, nil, nil)
+}
+
+// RecordExecutionWithParams is the full-fidelity recording method. It
+// behaves identically to RecordExecutionWithTiming but also persists
+// the env vars and make flags supplied via the params form (issue #37).
+// Both env and flags may be nil for runs that didn't use parameters.
+func (h *History) RecordExecutionWithParams(makefilePath, targetName string, duration time.Duration, success bool, env map[string]string, flags []string) {
 	now := time.Now()
 
 	entries := h.Entries[makefilePath]
@@ -134,6 +149,8 @@ func (h *History) RecordExecutionWithTiming(makefilePath, targetName string, dur
 					Duration:  duration,
 					Timestamp: now,
 					Success:   success,
+					Env:       env,
+					Flags:     flags,
 				}
 				entries[i].RecentExecutions = append(entries[i].RecentExecutions, exec)
 
@@ -162,6 +179,8 @@ func (h *History) RecordExecutionWithTiming(makefilePath, targetName string, dur
 				Duration:  duration,
 				Timestamp: now,
 				Success:   success,
+				Env:       env,
+				Flags:     flags,
 			}}
 		}
 

--- a/internal/history/history_test.go
+++ b/internal/history/history_test.go
@@ -4,9 +4,62 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
+
+// TestRecordExecutionWithParams covers issue #37: env and flags are
+// persisted alongside the timing record so post-mortem inspection (and
+// future preset/rerun features) can see exactly how a target was run.
+func TestRecordExecutionWithParams(t *testing.T) {
+	h := newEmptyHistory()
+	env := map[string]string{"FOO": "bar"}
+	flags := []string{"-j4", "-k"}
+
+	h.RecordExecutionWithParams("/test/Makefile", "build", 250*time.Millisecond, true, env, flags)
+
+	entries := h.Entries["/test/Makefile"]
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if len(entries[0].RecentExecutions) != 1 {
+		t.Fatalf("expected 1 execution record, got %d", len(entries[0].RecentExecutions))
+	}
+	rec := entries[0].RecentExecutions[0]
+	if !reflect.DeepEqual(rec.Env, env) {
+		t.Errorf("env: got %v, want %v", rec.Env, env)
+	}
+	if !reflect.DeepEqual(rec.Flags, flags) {
+		t.Errorf("flags: got %v, want %v", rec.Flags, flags)
+	}
+}
+
+// TestRecordExecutionWithTimingOmitsParams confirms the legacy
+// RecordExecutionWithTiming entry point leaves env/flags nil, so plain
+// runs continue to serialize identically.
+func TestRecordExecutionWithTimingOmitsParams(t *testing.T) {
+	h := newEmptyHistory()
+	h.RecordExecutionWithTiming("/test/Makefile", "build", 250*time.Millisecond, true)
+
+	rec := h.Entries["/test/Makefile"][0].RecentExecutions[0]
+	if rec.Env != nil {
+		t.Errorf("expected nil env for legacy timing call, got %v", rec.Env)
+	}
+	if rec.Flags != nil {
+		t.Errorf("expected nil flags for legacy timing call, got %v", rec.Flags)
+	}
+
+	// And the JSON form must not contain env/flags keys.
+	data, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(data); strings.Contains(got, `"env"`) || strings.Contains(got, `"flags"`) {
+		t.Errorf("expected omitempty to drop env/flags from JSON, got: %s", got)
+	}
+}
 
 func TestLoad_NonExistentFile(t *testing.T) {
 	h := &History{

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/progress"
 	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/rshelekhov/lazymake/config"
@@ -37,6 +38,13 @@ const (
 	StateConfirmDangerous
 	StateVariables
 	StateWorkspace
+	StateRunParams // Interactive form for env vars and make flags (issue #37)
+)
+
+// Indices for the focused field in the run-params form.
+const (
+	paramsFieldEnv   = 0
+	paramsFieldFlags = 1
 )
 
 type Model struct {
@@ -79,6 +87,31 @@ type Model struct {
 
 	// Confirmation state
 	PendingTarget *Target // Target awaiting dangerous command confirmation
+
+	// Interactive execution parameters (issue #37).
+	// ParamsEnvInput and ParamsFlagsInput are lazily initialized on first
+	// openParamsForm call so we don't allocate textinputs for users who
+	// never open the form. ParamsFocus tracks which input is active.
+	// ParamsTarget pins the target the form was opened for so cursor
+	// movement in the list doesn't change what gets executed.
+	// ParamsError holds the latest validation error, displayed inline.
+	// LastRunParams caches the last submitted params per target name so
+	// reopening the form pre-fills the previous values; it lives only
+	// for the current session.
+	// CurrentRunOpts carries parsed params from the form through the
+	// (optional) dangerous-confirmation step into the executor and on
+	// to history/export bookkeeping in handleExecutionComplete.
+	ParamsEnvInput   textinput.Model
+	ParamsFlagsInput textinput.Model
+	ParamsFocus      int
+	ParamsTarget     *Target
+	ParamsError      string
+	LastRunParams    map[string]ExecutionParams
+	CurrentRunOpts   executor.ExecutionOptions
+	// LastRunOpts mirrors CurrentRunOpts at the moment a run finished,
+	// so the output view can display the env/flags that were used even
+	// after CurrentRunOpts is cleared.
+	LastRunOpts executor.ExecutionOptions
 
 	// Execution timing
 	ExecutionStartTime time.Time
@@ -254,6 +287,10 @@ func NewModel(cfg *config.Config) Model {
 			key.WithHelp("enter", "run"),
 		),
 		key.NewBinding(
+			key.WithKeys("e"),
+			key.WithHelp("e", "run with params"),
+		),
+		key.NewBinding(
 			key.WithKeys("/"),
 			key.WithHelp("/", "filter"),
 		),
@@ -348,6 +385,7 @@ func NewModel(cfg *config.Config) Model {
 		Highlighter:       highlighter,
 		KeyBindings:       keyBindings,
 		StreamingOutput:   &strings.Builder{},
+		LastRunParams:     make(map[string]ExecutionParams),
 	}
 }
 

--- a/internal/tui/params.go
+++ b/internal/tui/params.go
@@ -1,0 +1,143 @@
+package tui
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ExecutionParams captures one form submission for a target. EnvRaw and
+// FlagsRaw are kept verbatim so the user can edit the same string the
+// next time the form opens; Env and Flags are the parsed equivalents
+// passed down to the executor.
+type ExecutionParams struct {
+	EnvRaw   string
+	FlagsRaw string
+	Env      map[string]string
+	Flags    []string
+}
+
+// IsEmpty reports whether no params were specified. A run with empty
+// params behaves identically to a plain `make <target>` invocation.
+func (p ExecutionParams) IsEmpty() bool {
+	return len(p.Env) == 0 && len(p.Flags) == 0
+}
+
+// parseEnvLine parses a whitespace-separated list of KEY=VALUE pairs.
+// Double-quoted values may contain spaces:
+//
+//	FOO=bar BAZ="hello world" EMPTY=
+//
+// Returns an error on the first malformed token. The error message
+// names the offending token so users can correct it in place.
+func parseEnvLine(s string) (map[string]string, error) {
+	tokens, err := shellSplit(s)
+	if err != nil {
+		return nil, err
+	}
+	if len(tokens) == 0 {
+		return nil, nil
+	}
+
+	out := make(map[string]string, len(tokens))
+	for _, tok := range tokens {
+		eq := strings.IndexByte(tok, '=')
+		if eq <= 0 {
+			return nil, fmt.Errorf("env: expected KEY=VALUE, got %q", tok)
+		}
+		key := tok[:eq]
+		if !isValidEnvKey(key) {
+			return nil, fmt.Errorf("env: invalid key %q (use letters, digits, underscore; not starting with a digit)", key)
+		}
+		out[key] = tok[eq+1:]
+	}
+	return out, nil
+}
+
+// parseFlagsLine parses a whitespace-separated list of make flags.
+// Every token must start with '-' so we can reject obvious user
+// mistakes like putting variables here instead of in the env field.
+//
+//	-j4 -k --always-make
+//
+// Quoted values are accepted but unusual for flags; we still support
+// them for consistency with parseEnvLine.
+func parseFlagsLine(s string) ([]string, error) {
+	tokens, err := shellSplit(s)
+	if err != nil {
+		return nil, err
+	}
+	if len(tokens) == 0 {
+		return nil, nil
+	}
+	for _, tok := range tokens {
+		if !strings.HasPrefix(tok, "-") {
+			if strings.Contains(tok, "=") {
+				return nil, fmt.Errorf("flags: %q looks like a variable; put it in the env field instead", tok)
+			}
+			return nil, fmt.Errorf("flags: %q does not start with '-'", tok)
+		}
+	}
+	return tokens, nil
+}
+
+// isValidEnvKey returns true if s is a portable env var name:
+//
+//	[A-Za-z_][A-Za-z0-9_]*
+//
+// This is the POSIX shell rule. We intentionally do not accept names
+// starting with a digit, even though some make versions tolerate it.
+func isValidEnvKey(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		if r == '_' || (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') {
+			continue
+		}
+		if i > 0 && r >= '0' && r <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// shellSplit splits s on whitespace, honoring double quotes so values
+// like `MSG="hello world"` survive as a single token. It is a small,
+// dependency-free subset of POSIX shell tokenization: it does not
+// handle single quotes, escapes, or environment-variable expansion.
+//
+// Returns an error if a quote is left unterminated.
+func shellSplit(s string) ([]string, error) {
+	var tokens []string
+	var cur strings.Builder
+	inQuote := false
+	hasContent := false
+
+	flush := func() {
+		if hasContent {
+			tokens = append(tokens, cur.String())
+		}
+		cur.Reset()
+		hasContent = false
+	}
+
+	for _, r := range s {
+		switch {
+		case r == '"':
+			inQuote = !inQuote
+			hasContent = true // an empty quoted string is still a token
+		case !inQuote && (r == ' ' || r == '\t'):
+			flush()
+		default:
+			cur.WriteRune(r)
+			hasContent = true
+		}
+	}
+	if inQuote {
+		return nil, errors.New("unterminated double quote")
+	}
+	flush()
+	return tokens, nil
+}

--- a/internal/tui/params_test.go
+++ b/internal/tui/params_test.go
@@ -1,0 +1,256 @@
+package tui
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/rshelekhov/lazymake/internal/history"
+)
+
+func TestParseEnvLine(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    map[string]string
+		wantErr bool
+	}{
+		{name: "empty", in: "", want: nil},
+		{name: "single", in: "FOO=bar", want: map[string]string{"FOO": "bar"}},
+		{name: "multiple", in: "A=1 B=2 C=3", want: map[string]string{"A": "1", "B": "2", "C": "3"}},
+		{name: "empty value", in: "FOO=", want: map[string]string{"FOO": ""}},
+		{name: "quoted value with spaces", in: `MSG="hello world"`, want: map[string]string{"MSG": "hello world"}},
+		{name: "leading whitespace", in: "  FOO=bar  ", want: map[string]string{"FOO": "bar"}},
+		{name: "missing equals", in: "FOO", wantErr: true},
+		{name: "missing key", in: "=bar", wantErr: true},
+		{name: "key starts with digit", in: "1FOO=bar", wantErr: true},
+		{name: "key with hyphen", in: "FOO-BAR=baz", wantErr: true},
+		{name: "unterminated quote", in: `FOO="bar`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseEnvLine(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil (result: %v)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseFlagsLine(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    []string
+		wantErr bool
+	}{
+		{name: "empty", in: "", want: nil},
+		{name: "single short", in: "-j4", want: []string{"-j4"}},
+		{name: "multiple", in: "-j4 -k --always-make", want: []string{"-j4", "-k", "--always-make"}},
+		{name: "looks like variable", in: "FOO=bar", wantErr: true},
+		{name: "no leading dash", in: "j4", wantErr: true},
+		{name: "mixed valid and invalid", in: "-k j4", wantErr: true},
+		{name: "unterminated quote", in: `-k "foo`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseFlagsLine(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil (result: %v)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShellSplit(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    []string
+		wantErr bool
+	}{
+		{name: "empty", in: "", want: nil},
+		{name: "single", in: "foo", want: []string{"foo"}},
+		{name: "multiple", in: "foo bar baz", want: []string{"foo", "bar", "baz"}},
+		{name: "tabs", in: "foo\tbar", want: []string{"foo", "bar"}},
+		{name: "quoted", in: `foo "bar baz"`, want: []string{"foo", "bar baz"}},
+		{name: "embedded quote", in: `K="v 1"`, want: []string{"K=v 1"}},
+		{name: "unterminated", in: `"foo`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := shellSplit(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// makeParamsTestModel builds a minimal Model suitable for exercising the
+// params form FSM. It avoids touching the disk by giving History an
+// in-memory map and leaving Exporter/ShellIntegration nil.
+func makeParamsTestModel(t *testing.T) Model {
+	t.Helper()
+	hist := &history.History{Entries: make(map[string][]history.Entry)}
+	l := list.New(nil, NewItemDelegate(), 0, 0)
+	return Model{
+		List:            l,
+		History:         hist,
+		MakefilePath:    "/tmp/test-Makefile",
+		StreamingOutput: &strings.Builder{},
+		LastRunParams:   make(map[string]ExecutionParams),
+	}
+}
+
+// TestParamsCancel verifies Esc returns to list with no history append.
+// This covers the AC: "Cancel path returns to the list without execution."
+func TestParamsCancel(t *testing.T) {
+	m := makeParamsTestModel(t)
+	target := Target{Name: "build"}
+	m.initParamsForm(&target)
+	m.State = StateRunParams
+
+	updated, _ := m.updateRunParams(tea.KeyMsg{Type: tea.KeyEsc})
+	mm := updated.(Model)
+
+	if mm.State != StateList {
+		t.Errorf("expected state=StateList after Esc, got %v", mm.State)
+	}
+	if mm.ParamsTarget != nil {
+		t.Error("expected ParamsTarget to be cleared after Esc")
+	}
+	if got := len(mm.History.Entries[mm.MakefilePath]); got != 0 {
+		t.Errorf("expected 0 history entries after cancel, got %d", got)
+	}
+}
+
+// TestParamsSubmitValid verifies a valid submission transitions to
+// StateExecuting and populates CurrentRunOpts with parsed values.
+func TestParamsSubmitValid(t *testing.T) {
+	m := makeParamsTestModel(t)
+	target := Target{Name: "build"}
+	m.initParamsForm(&target)
+	m.State = StateRunParams
+	m.ParamsEnvInput.SetValue("FOO=bar")
+	m.ParamsFlagsInput.SetValue("-j4")
+
+	updated, _ := m.updateRunParams(tea.KeyMsg{Type: tea.KeyEnter})
+	mm := updated.(Model)
+
+	if mm.State != StateExecuting {
+		t.Errorf("expected state=StateExecuting after valid submit, got %v", mm.State)
+	}
+	if mm.CurrentRunOpts.Env["FOO"] != "bar" {
+		t.Errorf("expected CurrentRunOpts.Env[FOO]=bar, got %v", mm.CurrentRunOpts.Env)
+	}
+	if len(mm.CurrentRunOpts.Flags) != 1 || mm.CurrentRunOpts.Flags[0] != "-j4" {
+		t.Errorf("expected CurrentRunOpts.Flags=[-j4], got %v", mm.CurrentRunOpts.Flags)
+	}
+	cached, ok := mm.LastRunParams["build"]
+	if !ok {
+		t.Fatal("expected LastRunParams to be populated for build")
+	}
+	if cached.EnvRaw != "FOO=bar" || cached.FlagsRaw != "-j4" {
+		t.Errorf("LastRunParams raw mismatch: %+v", cached)
+	}
+}
+
+// TestParamsSubmitInvalidStaysInForm verifies a validation error keeps
+// the user in StateRunParams with ParamsError set, and does NOT append
+// to history.
+func TestParamsSubmitInvalidStaysInForm(t *testing.T) {
+	m := makeParamsTestModel(t)
+	target := Target{Name: "build"}
+	m.initParamsForm(&target)
+	m.State = StateRunParams
+	m.ParamsEnvInput.SetValue("not-a-valid-pair") // missing '='
+
+	updated, _ := m.updateRunParams(tea.KeyMsg{Type: tea.KeyEnter})
+	mm := updated.(Model)
+
+	if mm.State != StateRunParams {
+		t.Errorf("expected to remain in StateRunParams on invalid input, got %v", mm.State)
+	}
+	if mm.ParamsError == "" {
+		t.Error("expected ParamsError to be set on invalid input")
+	}
+	if got := len(mm.History.Entries[mm.MakefilePath]); got != 0 {
+		t.Errorf("expected 0 history entries on validation failure, got %d", got)
+	}
+}
+
+// TestParamsTabTogglesFocus verifies Tab swaps focus between inputs.
+func TestParamsTabTogglesFocus(t *testing.T) {
+	m := makeParamsTestModel(t)
+	target := Target{Name: "build"}
+	m.initParamsForm(&target)
+	m.State = StateRunParams
+
+	if m.ParamsFocus != paramsFieldEnv {
+		t.Fatalf("expected initial focus on env, got %d", m.ParamsFocus)
+	}
+
+	updated, _ := m.updateRunParams(tea.KeyMsg{Type: tea.KeyTab})
+	mm := updated.(Model)
+	if mm.ParamsFocus != paramsFieldFlags {
+		t.Errorf("after Tab expected focus=flags, got %d", mm.ParamsFocus)
+	}
+
+	updated, _ = mm.updateRunParams(tea.KeyMsg{Type: tea.KeyTab})
+	mm = updated.(Model)
+	if mm.ParamsFocus != paramsFieldEnv {
+		t.Errorf("after second Tab expected focus=env, got %d", mm.ParamsFocus)
+	}
+}
+
+// TestParamsPrefillsFromLastRunParams verifies opening the form for a
+// target that was previously run with params restores those values.
+func TestParamsPrefillsFromLastRunParams(t *testing.T) {
+	m := makeParamsTestModel(t)
+	m.LastRunParams["deploy"] = ExecutionParams{
+		EnvRaw:   `ENV=prod TOKEN="ab cd"`,
+		FlagsRaw: "-j2",
+	}
+	target := Target{Name: "deploy"}
+	m.initParamsForm(&target)
+
+	if got := m.ParamsEnvInput.Value(); got != `ENV=prod TOKEN="ab cd"` {
+		t.Errorf("env not prefilled: got %q", got)
+	}
+	if got := m.ParamsFlagsInput.Value(); got != "-j2" {
+		t.Errorf("flags not prefilled: got %q", got)
+	}
+}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -44,6 +44,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateVariables(msg)
 	case StateWorkspace:
 		return m.updateWorkspace(msg)
+	case StateRunParams:
+		return m.updateRunParams(msg)
 	default:
 		return m, nil
 	}
@@ -105,6 +107,8 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleGraphView()
 	case "enter":
 		return m.handleTargetSelection()
+	case "e":
+		return m.handleOpenParamsForm()
 	case "ctrl+d":
 		m.RecipeViewport.HalfPageDown()
 		return m, nil
@@ -220,13 +224,20 @@ func (m Model) handleGraphView() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// handleTargetSelection executes or confirms the selected target
+// handleTargetSelection executes or confirms the selected target.
+// This is the quick-run path (Enter from the list) — no env/flags;
+// the parameterized path goes through handleOpenParamsForm.
 func (m Model) handleTargetSelection() (tea.Model, tea.Cmd) {
 	selected := m.List.SelectedItem()
 	target, ok := selected.(Target)
 	if !ok {
 		return m, nil
 	}
+
+	// Plain Enter must never inherit params from a previous form
+	// submission. Reset CurrentRunOpts so dangerous-confirm and
+	// startExecution see a clean slate.
+	m.CurrentRunOpts = executor.ExecutionOptions{DryRun: m.DryRun}
 
 	// Check if target is critical and requires confirmation
 	if target.IsDangerous && target.DangerLevel == safety.SeverityCritical {
@@ -236,32 +247,7 @@ func (m Model) handleTargetSelection() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// Safe or non-critical target - execute immediately.
-	// In dry-run mode we skip history recording so preview-only runs
-	// don't pollute the RECENT list or perf stats (issue #38).
-	if !m.DryRun {
-		m.History.RecordExecution(m.MakefilePath, target.Name)
-		_ = m.History.Save()
-
-		// Refresh recent targets for next render
-		recentEntries := m.History.GetRecent(m.MakefilePath)
-		m.RecentTargets = buildRecentTargets(recentEntries, m.Targets)
-	}
-
-	m.State = StateExecuting
-	m.ExecutingTarget = target.Name
-	m.ExecutionStartTime = time.Now()
-	m.ExecutionElapsed = 0
-
-	// Reset streaming output and initialize viewport
-	m.StreamingOutput = &strings.Builder{}
-	m.initExecutingViewport()
-
-	return m, tea.Batch(
-		executeTargetStreaming(target.Name, m.MakefilePath, m.DryRun),
-		tickTimer(),
-		m.Spinner.Tick,
-	)
+	return m.startExecution(target, m.CurrentRunOpts)
 }
 
 // handleWindowResize updates dimensions and layout when window size changes
@@ -607,9 +593,17 @@ func (m Model) handleExecutionComplete(err error) (tea.Model, tea.Cmd) {
 	// integration entries. We still build the Result for the output view
 	// so the user can read what `make -n` printed.
 	if !m.DryRun {
-		// Record execution with timing data
+		// Record execution with timing data and (if present) the
+		// interactive-form parameters from issue #37.
 		success := err == nil
-		m.History.RecordExecutionWithTiming(m.MakefilePath, m.ExecutingTarget, duration, success)
+		m.History.RecordExecutionWithParams(
+			m.MakefilePath,
+			m.ExecutingTarget,
+			duration,
+			success,
+			m.CurrentRunOpts.Env,
+			m.CurrentRunOpts.Flags,
+		)
 		_ = m.History.Save() // Async, ignore errors
 	}
 
@@ -633,11 +627,17 @@ func (m Model) handleExecutionComplete(err error) (tea.Model, tea.Cmd) {
 
 	// Export execution result (async, non-blocking) — skipped in dry-run.
 	if m.Exporter != nil && !m.DryRun {
+		// Snapshot params before the goroutine so the cleanup below
+		// can clear CurrentRunOpts without racing.
+		env := m.CurrentRunOpts.Env
+		flags := m.CurrentRunOpts.Flags
 		go func() {
-			record := export.NewExecutionRecord(
+			record := export.NewExecutionRecordWithParams(
 				m.MakefilePath,
 				m.ExecutingTarget,
 				result,
+				env,
+				flags,
 			)
 			if err := m.Exporter.Export(record); err != nil {
 				_, _ = fmt.Fprintf(os.Stderr, "Export failed: %v\n", err)
@@ -668,15 +668,20 @@ func (m Model) handleExecutionComplete(err error) (tea.Model, tea.Cmd) {
 		m.List.SetItems(updatedItems)
 	}
 
-	// Transition to output view
+	// Transition to output view. Pin LastRunOpts so the output header
+	// can show env/flags even after we clear CurrentRunOpts.
+	m.LastRunOpts = m.CurrentRunOpts
+
 	m.State = StateOutput
 	m.Output = m.StreamingOutput.String()
 	m.ExecutionError = err
 	m.initViewport(m.Output)
 
-	// Clean up
+	// Clean up: drop CurrentRunOpts so a subsequent quick-Enter doesn't
+	// inherit the last run's parameters.
 	m.CancelExecution = nil
 	m.OutputChunks = nil
+	m.CurrentRunOpts = executor.ExecutionOptions{}
 
 	return m, nil
 }
@@ -802,35 +807,18 @@ func (m Model) updateConfirmDangerous(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Per ACR for #38: dangerous targets still show this confirm
 			// dialog in dry-run mode, but the actual run uses `make -n`
 			// and skips history recording.
+			//
+			// Per issue #37: if the user arrived here via the params
+			// form, m.CurrentRunOpts carries the parsed env+flags.
+			// For the plain Enter-from-list path CurrentRunOpts is the
+			// zero value, with DryRun still respected via startExecution.
 			if m.PendingTarget != nil {
 				target := *m.PendingTarget
-
-				if !m.DryRun {
-					// Record execution in history
-					m.History.RecordExecution(m.MakefilePath, target.Name)
-					_ = m.History.Save()
-
-					// Refresh recent targets
-					recentEntries := m.History.GetRecent(m.MakefilePath)
-					m.RecentTargets = buildRecentTargets(recentEntries, m.Targets)
-				}
-
-				// Clear pending target and start execution
 				m.PendingTarget = nil
-				m.State = StateExecuting
-				m.ExecutingTarget = target.Name
-				m.ExecutionStartTime = time.Now()
-				m.ExecutionElapsed = 0
 
-				// Reset streaming output and initialize viewport
-				m.StreamingOutput = &strings.Builder{}
-				m.initExecutingViewport()
-
-				return m, tea.Batch(
-					executeTargetStreaming(target.Name, m.MakefilePath, m.DryRun),
-					tickTimer(),   // Start timer
-					m.Spinner.Tick, // Start spinner animation
-				)
+				opts := m.CurrentRunOpts
+				opts.DryRun = m.DryRun // session flag always wins over stale form state
+				return m.startExecution(target, opts)
 			}
 		}
 
@@ -865,11 +853,11 @@ func tickTimer() tea.Cmd {
 }
 
 // executeTargetStreaming starts streaming execution.
-// When dryRun is true, the executor invokes `make -n` to preview commands
-// without running them.
-func executeTargetStreaming(target, makefilePath string, dryRun bool) tea.Cmd {
+// Options control dry-run mode, additional env vars, and extra make
+// flags. See executor.ExecutionOptions for details.
+func executeTargetStreaming(target, makefilePath string, opts executor.ExecutionOptions) tea.Cmd {
 	return func() tea.Msg {
-		chunks, cancel := executor.ExecuteStreaming(target, makefilePath, dryRun)
+		chunks, cancel := executor.ExecuteStreaming(target, makefilePath, opts)
 		return streamStartedMsg{chunks: chunks, cancel: cancel}
 	}
 }

--- a/internal/tui/update_params.go
+++ b/internal/tui/update_params.go
@@ -1,0 +1,221 @@
+package tui
+
+import (
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/rshelekhov/lazymake/internal/executor"
+	"github.com/rshelekhov/lazymake/internal/safety"
+)
+
+// handleOpenParamsForm transitions from the list view to the params
+// form for the currently selected target. Bound to the "e" key.
+//
+// The form is pre-filled from LastRunParams if the user has run this
+// target with params before in the current session.
+func (m Model) handleOpenParamsForm() (tea.Model, tea.Cmd) {
+	selected := m.List.SelectedItem()
+	target, ok := selected.(Target)
+	if !ok {
+		return m, nil
+	}
+
+	m.initParamsForm(&target)
+	m.State = StateRunParams
+	return m, textinput.Blink
+}
+
+// initParamsForm lazily creates the two textinputs and seeds their
+// values from LastRunParams[target.Name] if present. Safe to call
+// repeatedly; reinitializes each time so the form always opens fresh.
+func (m *Model) initParamsForm(target *Target) {
+	// Container border (2) + padding (4) + prompt width (8) = 14
+	// chars of chrome before the input itself. Default to 60 when
+	// the model hasn't been sized yet (mostly tests).
+	inputWidth := 60
+	if m.Width > 14 {
+		inputWidth = m.Width - 14
+	}
+
+	envInput := textinput.New()
+	envInput.Placeholder = "KEY=value KEY2=value"
+	envInput.Prompt = "ENV   > "
+	envInput.CharLimit = 1024
+	envInput.Width = inputWidth
+
+	flagsInput := textinput.New()
+	flagsInput.Placeholder = "-j4 -k --always-make"
+	flagsInput.Prompt = "FLAGS > "
+	flagsInput.CharLimit = 1024
+	flagsInput.Width = inputWidth
+
+	// Pre-fill from session cache when available.
+	if prev, ok := m.LastRunParams[target.Name]; ok {
+		envInput.SetValue(prev.EnvRaw)
+		flagsInput.SetValue(prev.FlagsRaw)
+	}
+
+	envInput.Focus()
+
+	m.ParamsEnvInput = envInput
+	m.ParamsFlagsInput = flagsInput
+	m.ParamsFocus = paramsFieldEnv
+	m.ParamsTarget = target
+	m.ParamsError = ""
+}
+
+// updateRunParams handles key input while the params form is active.
+//
+// Esc cancels with no side effects. Tab toggles focus between the two
+// inputs. Enter parses both fields; on success it stores the parsed
+// values in LastRunParams and m.CurrentRunOpts, then transitions to
+// the executor (or to dangerous confirmation, for critical targets).
+func (m Model) updateRunParams(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyEsc:
+			return m.cancelParamsForm(), nil
+		case tea.KeyTab, tea.KeyShiftTab:
+			m = m.toggleParamsFocus()
+			return m, nil
+		case tea.KeyEnter:
+			return m.submitParamsForm()
+		}
+		// Ctrl+C still quits.
+		if msg.String() == "ctrl+c" {
+			return m, tea.Quit
+		}
+	case tea.WindowSizeMsg:
+		m.Width = msg.Width
+		m.Height = msg.Height
+		// Re-fit textinput widths to the new terminal width without
+		// touching the current values or focus state.
+		inputWidth := 60
+		if m.Width > 14 {
+			inputWidth = m.Width - 14
+		}
+		m.ParamsEnvInput.Width = inputWidth
+		m.ParamsFlagsInput.Width = inputWidth
+	}
+
+	// Forward all other keys to the focused input.
+	var cmd tea.Cmd
+	if m.ParamsFocus == paramsFieldEnv {
+		m.ParamsEnvInput, cmd = m.ParamsEnvInput.Update(msg)
+	} else {
+		m.ParamsFlagsInput, cmd = m.ParamsFlagsInput.Update(msg)
+	}
+	return m, cmd
+}
+
+// cancelParamsForm returns to the list view without running anything.
+// Per the issue #37 acceptance criteria: cancel path performs no
+// history, export, or shell-integration side effects.
+func (m Model) cancelParamsForm() Model {
+	m.State = StateList
+	m.ParamsTarget = nil
+	m.ParamsError = ""
+	return m
+}
+
+// toggleParamsFocus moves focus between the env and flags inputs.
+func (m Model) toggleParamsFocus() Model {
+	if m.ParamsFocus == paramsFieldEnv {
+		m.ParamsEnvInput.Blur()
+		m.ParamsFlagsInput.Focus()
+		m.ParamsFocus = paramsFieldFlags
+	} else {
+		m.ParamsFlagsInput.Blur()
+		m.ParamsEnvInput.Focus()
+		m.ParamsFocus = paramsFieldEnv
+	}
+	return m
+}
+
+// submitParamsForm validates the two inputs and either starts execution
+// (or dangerous-confirmation) on success, or leaves the user in the
+// form with ParamsError set on failure.
+func (m Model) submitParamsForm() (tea.Model, tea.Cmd) {
+	if m.ParamsTarget == nil {
+		// Defensive: should not happen in practice, but treat as cancel.
+		return m.cancelParamsForm(), nil
+	}
+
+	envRaw := m.ParamsEnvInput.Value()
+	flagsRaw := m.ParamsFlagsInput.Value()
+
+	env, err := parseEnvLine(envRaw)
+	if err != nil {
+		m.ParamsError = err.Error()
+		return m, nil
+	}
+	flags, err := parseFlagsLine(flagsRaw)
+	if err != nil {
+		m.ParamsError = err.Error()
+		return m, nil
+	}
+
+	target := *m.ParamsTarget
+	parsed := ExecutionParams{
+		EnvRaw:   envRaw,
+		FlagsRaw: flagsRaw,
+		Env:      env,
+		Flags:    flags,
+	}
+	if m.LastRunParams == nil {
+		m.LastRunParams = make(map[string]ExecutionParams)
+	}
+	m.LastRunParams[target.Name] = parsed
+
+	m.CurrentRunOpts = executor.ExecutionOptions{
+		DryRun: m.DryRun,
+		Env:    env,
+		Flags:  flags,
+	}
+
+	// Dangerous critical targets still go through confirmation, but
+	// now with the freshly-parsed params already attached.
+	if target.IsDangerous && target.DangerLevel == safety.SeverityCritical {
+		targetCopy := target
+		m.PendingTarget = &targetCopy
+		m.State = StateConfirmDangerous
+		m.ParamsError = ""
+		return m, nil
+	}
+
+	return m.startExecution(target, m.CurrentRunOpts)
+}
+
+// startExecution is the single entry point into StateExecuting used by
+// both the quick-run path (Enter from the list) and the parameterized
+// path (form submission, optionally via dangerous confirmation).
+//
+// It updates history (skipped in dry-run, matching existing #38
+// behavior) and kicks off the streaming executor.
+func (m Model) startExecution(target Target, opts executor.ExecutionOptions) (tea.Model, tea.Cmd) {
+	if !m.DryRun {
+		m.History.RecordExecution(m.MakefilePath, target.Name)
+		_ = m.History.Save()
+		recentEntries := m.History.GetRecent(m.MakefilePath)
+		m.RecentTargets = buildRecentTargets(recentEntries, m.Targets)
+	}
+
+	m.State = StateExecuting
+	m.ExecutingTarget = target.Name
+	m.ExecutionStartTime = time.Now()
+	m.ExecutionElapsed = 0
+	m.ParamsTarget = nil
+	m.ParamsError = ""
+
+	m.StreamingOutput = &strings.Builder{}
+	m.initExecutingViewport()
+
+	return m, tea.Batch(
+		executeTargetStreaming(target.Name, m.MakefilePath, opts),
+		tickTimer(),
+		m.Spinner.Tick,
+	)
+}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -27,6 +27,8 @@ func (m Model) View() string {
 		return m.renderOutputView()
 	case StateConfirmDangerous:
 		return m.renderConfirmView()
+	case StateRunParams:
+		return m.renderRunParamsView()
 	case StateVariables:
 		return m.renderVariablesView()
 	case StateWorkspace:
@@ -353,6 +355,12 @@ func (m Model) renderOutputView() string {
 			Render("[DRY-RUN]")
 	}
 	util.WriteString(&builder, header+"\n")
+
+	// Echo run parameters (issue #37) so the output clearly reflects
+	// the env vars and make flags that were applied to this run.
+	if paramsLine := renderParamsLine(m.LastRunOpts); paramsLine != "" {
+		util.WriteString(&builder, paramsLine+"\n")
+	}
 
 	// Check for performance regression
 	for _, target := range m.Targets {

--- a/internal/tui/view_params.go
+++ b/internal/tui/view_params.go
@@ -1,0 +1,155 @@
+package tui
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/rshelekhov/lazymake/internal/executor"
+	"github.com/rshelekhov/lazymake/internal/util"
+)
+
+// renderRunParamsView draws the interactive form for environment
+// variables and make flags (issue #37). The layout mirrors the
+// dependency-graph view: full-width container with a rounded border
+// on top, status bar (workspace path nugget + shortcuts) on the
+// bottom.
+func (m Model) renderRunParamsView() string {
+	if m.Width == 0 || m.Height == 0 {
+		return "Loading run parameters..."
+	}
+
+	content := m.renderRunParamsContent(m.Width)
+	statusBar := m.renderRunParamsStatusBar(m.Width)
+
+	return lipgloss.JoinVertical(lipgloss.Left, content, statusBar)
+}
+
+// renderRunParamsContent renders the bordered form area.
+func (m Model) renderRunParamsContent(width int) string {
+	var builder strings.Builder
+
+	// Title
+	title := TitleStyle.Render("Run Parameters")
+	util.WriteString(&builder, title+"\n\n")
+
+	// Target name
+	if m.ParamsTarget != nil {
+		targetInfo := lipgloss.NewStyle().
+			Foreground(PrimaryColor).
+			Bold(true).
+			Render("Target: " + m.ParamsTarget.Name)
+		util.WriteString(&builder, targetInfo+"\n")
+
+		if m.ParamsTarget.Description != "" {
+			desc := lipgloss.NewStyle().
+				Foreground(TextMuted).
+				Render(m.ParamsTarget.Description)
+			util.WriteString(&builder, desc+"\n")
+		}
+	}
+	util.WriteString(&builder, "\n")
+
+	// Inputs
+	util.WriteString(&builder, m.ParamsEnvInput.View()+"\n")
+	util.WriteString(&builder, m.ParamsFlagsInput.View()+"\n\n")
+
+	// Hint about syntax
+	hint := lipgloss.NewStyle().
+		Foreground(TextMuted).
+		Italic(true).
+		Render("Tip: KEY=value pairs in env, quote values with spaces: MSG=\"hi there\"")
+	util.WriteString(&builder, hint)
+
+	// Inline validation error, if any
+	if m.ParamsError != "" {
+		errLine := lipgloss.NewStyle().
+			Foreground(ErrorColor).
+			Bold(true).
+			Render("✗ " + m.ParamsError)
+		util.WriteString(&builder, "\n\n"+errLine)
+	}
+
+	// Container matches the dependency-graph view: rounded border,
+	// full width minus the border itself.
+	containerStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(BorderColor).
+		Padding(1, 2).
+		Width(width - 2)
+	return containerStyle.Render(builder.String())
+}
+
+// renderRunParamsStatusBar mirrors the dependency-graph status bar:
+// workspace path nugget on the left, shortcuts on the right.
+func (m Model) renderRunParamsStatusBar(width int) string {
+	statusBarStyle := lipgloss.NewStyle().Foreground(TextPrimary)
+
+	coloredNuggetStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.AdaptiveColor{Light: "#FFFFFF", Dark: "#000000"}).
+		Background(PrimaryColor).
+		Padding(0, 1).
+		MarginRight(1)
+
+	workspacePath := m.getWorkspaceDisplayPath()
+	pathNugget := coloredNuggetStyle.Render(workspacePath)
+
+	leftBar := lipgloss.JoinHorizontal(lipgloss.Top, pathNugget)
+	leftWidth := lipgloss.Width(leftBar)
+
+	helpText := "enter: run • tab: switch field • esc: cancel • q: quit"
+	right := lipgloss.NewStyle().
+		Foreground(TextMuted).
+		Padding(0, 1).
+		Render(helpText)
+	rightWidth := lipgloss.Width(right)
+
+	// Account for status bar horizontal padding (1 left + 1 right = 2).
+	middleWidth := max(width-2-leftWidth-rightWidth, 1)
+	middle := lipgloss.NewStyle().
+		Width(middleWidth).
+		Align(lipgloss.Left).
+		Render("")
+
+	bar := lipgloss.JoinHorizontal(lipgloss.Top, leftBar, middle, right)
+
+	return statusBarStyle.
+		Width(width).
+		Padding(1, 1).
+		Render(bar)
+}
+
+// renderParamsLine formats env+flags as a single-line header for the
+// output view. Returns "" when opts carries no params, so callers can
+// omit the line entirely on plain runs.
+//
+// Example: `Params: ENV=prod TOKEN="ab cd"  Flags: -j4 -k`
+func renderParamsLine(opts executor.ExecutionOptions) string {
+	if len(opts.Env) == 0 && len(opts.Flags) == 0 {
+		return ""
+	}
+	labelStyle := lipgloss.NewStyle().Foreground(TextSecondary).Bold(true)
+	valueStyle := lipgloss.NewStyle().Foreground(TextMuted)
+
+	var parts []string
+	if len(opts.Env) > 0 {
+		keys := make([]string, 0, len(opts.Env))
+		for k := range opts.Env {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		pairs := make([]string, 0, len(keys))
+		for _, k := range keys {
+			v := opts.Env[k]
+			if strings.ContainsAny(v, " \t") {
+				v = `"` + v + `"`
+			}
+			pairs = append(pairs, k+"="+v)
+		}
+		parts = append(parts, labelStyle.Render("Env: ")+valueStyle.Render(strings.Join(pairs, " ")))
+	}
+	if len(opts.Flags) > 0 {
+		parts = append(parts, labelStyle.Render("Flags: ")+valueStyle.Render(strings.Join(opts.Flags, " ")))
+	}
+	return strings.Join(parts, "   ")
+}


### PR DESCRIPTION
Closes #37.

## Summary

Adds a pre-run form for environment variables and make flags. From the
target list, press `e` to open the form; Tab toggles between the ENV and
FLAGS fields, Enter validates and runs, Esc cancels without side
effects.

## Changes

- **executor**: `ExecuteStreaming` now takes `ExecutionOptions{DryRun, Env, Flags}` instead of a `bool`. Argv order is `-f path [-n] [user flags...] target`; env is merged on top of `os.Environ()` with sorted keys for deterministic invocation.
- **TUI**: new `StateRunParams` plus parsers (`parseEnvLine`, `parseFlagsLine`, `shellSplit`). The `e` key opens the form. Quick-Enter still works. Dangerous critical targets: params form → confirmation → run. Last-submitted params per target are cached in memory for the current session.
- **history / export**: `ExecutionRecord` types gain optional `Env`/`Flags` fields (`omitempty`, so plain runs serialize identically). `RecordExecutionWithParams` and `NewExecutionRecordWithParams` are the new full-fidelity entry points; existing constructors delegate with nil params.
- **Output view**: header echoes the env/flags that were applied.

## Acceptance criteria mapping

- *User can enter env vars* → env textinput + `parseEnvLine` (quoted values supported)
- *User can enter make flags* → flags textinput + `parseFlagsLine`
- *Command construction is safe and deterministic* → `exec.CommandContext("make", args...)` without a shell; sorted env keys; tests assert argv order
- *Cancel path returns to the list without execution* → Esc handler in `updateRunParams`; no history/export side effects (covered by test)
- *Output and history clearly reflect chosen parameters* → params in output view header, in history `Entry.RecentExecutions[].Env/Flags`, in export `ExecutionRecord.Env/Flags` + `FormatLog` lines

## UI

The form uses the same layout as the Dependency Graph view: full-width
rounded-border container on top, status bar (workspace path nugget +
shortcuts) on the bottom.

## Tests

- `executor_test.go` — argv/env construction, env reaches make, flag delegation
- `tui/params_test.go` — parsers + form FSM (cancel, submit valid, submit invalid stays in form, Tab toggles focus, prefill from session cache)
- `tui/dryrun_test.go` — existing dry-run tests still pass
- `history/history_test.go` — `RecordExecutionWithParams` persists env/flags; legacy path keeps them nil and JSON-omitted
- `export/record_params_test.go` — record fields + `FormatLog` `Env:`/`Flags:` lines

## Out of scope

- Persistent presets (#38)
- Rerun-last (#39)
- Writing the full command (with env+flags) to shell-integration history — current behavior unchanged