### PR TITLE
feat: saved run presets per target and Makefile (#35)

### DIFF
--- a/cmd/lazymake/main.go
+++ b/cmd/lazymake/main.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/rshelekhov/lazymake/config"
+	"github.com/rshelekhov/lazymake/internal/presets"
 	"github.com/rshelekhov/lazymake/internal/tui"
 	"github.com/rshelekhov/lazymake/internal/workspace"
 	"github.com/spf13/cobra"
@@ -47,8 +48,17 @@ func run(cmd *cobra.Command, args []string) error {
 		workspaceMgr = workspace.NewEmpty()
 	}
 
+	// Initialize saved presets manager (issue #35). Failures here
+	// degrade gracefully: an empty manager means "no presets yet",
+	// the rest of the TUI works as before.
+	presetsMgr, err := presets.Load()
+	if err != nil {
+		presetsMgr = presets.NewEmpty()
+	}
+
 	m := tui.NewModel(cfg)
 	m.WorkspaceManager = workspaceMgr
+	m.Presets = presetsMgr
 
 	p := tea.NewProgram(m, tea.WithAltScreen())
 

--- a/internal/presets/presets.go
+++ b/internal/presets/presets.go
@@ -1,0 +1,355 @@
+// Package presets provides persistent, named run configurations
+// (environment variables + make flags) for Makefile targets.
+//
+// A preset is identified by the tuple (absolute makefile path, target
+// name, preset name). Presets are stored in a single JSON file under
+// the user cache directory and follow the same graceful-degradation
+// pattern as internal/history: a missing or corrupt file results in an
+// empty manager and the rest of the app keeps running.
+package presets
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	presetsFileName = "presets.json"
+)
+
+// Preset captures one named configuration for a target.
+//
+// Env and Flags are omitted from JSON when empty so a "plain" preset
+// (e.g. one that just records the intent of running with no extras)
+// produces a compact on-disk representation.
+type Preset struct {
+	Name       string            `json:"name"`
+	Env        map[string]string `json:"env,omitempty"`
+	Flags      []string          `json:"flags,omitempty"`
+	CreatedAt  time.Time         `json:"created_at"`
+	UpdatedAt  time.Time         `json:"updated_at"`
+	LastUsedAt time.Time         `json:"last_used_at,omitempty"`
+}
+
+// TargetPresets is the bucket of presets for a single target. The
+// LastUsedPreset pointer is stored alongside the presets so the
+// "R: rerun last-used" hotkey can resolve in O(1) without scanning
+// LastUsedAt timestamps.
+type TargetPresets struct {
+	Presets        []Preset `json:"presets"`
+	LastUsedPreset string   `json:"last_used_preset,omitempty"`
+}
+
+// Manager owns the in-memory copy of presets.json and serializes
+// mutations through Save(). Concurrent use is not supported; the TUI
+// drives Manager from the single Bubble Tea event loop.
+type Manager struct {
+	// Entries[absoluteMakefilePath][targetName] -> bucket of presets.
+	// We use a pointer to TargetPresets so callers can take a reference,
+	// mutate, and have it round-trip through MarshalJSON unchanged.
+	Entries map[string]map[string]*TargetPresets `json:"entries"`
+
+	path string // file path; "" means "Save is a no-op"
+}
+
+// ErrPresetExists is returned by UpsertStrict when the (makefile,
+// target, name) tuple is already taken. The TUI uses this to decide
+// when to prompt the user with an "overwrite?" confirmation.
+var ErrPresetExists = errors.New("preset with this name already exists")
+
+// Load reads presets.json from the user cache directory. On any I/O
+// or parse failure it returns an empty (but writable) Manager along
+// with the error, matching the history package's graceful pattern so
+// callers can decide whether to log or silently ignore.
+func Load() (*Manager, error) {
+	path, err := getCachePath()
+	if err != nil {
+		return newEmpty(), fmt.Errorf("failed to get cache path: %w", err)
+	}
+	return LoadFrom(path)
+}
+
+// LoadFrom reads presets from an explicit path. Exposed primarily so
+// tests can point at t.TempDir() without monkey-patching the cache
+// directory.
+func LoadFrom(path string) (*Manager, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			m := newEmpty()
+			m.path = path
+			return m, nil
+		}
+		m := newEmpty()
+		m.path = path
+		return m, fmt.Errorf("failed to read presets file: %w", err)
+	}
+
+	var m Manager
+	if err := json.Unmarshal(data, &m); err != nil {
+		// Corrupt JSON: keep the user running with an empty store, but
+		// surface the problem on stderr so they can investigate.
+		_, _ = fmt.Fprintf(os.Stderr, "Warning: corrupt presets file, resetting: %v\n", err)
+		m = *newEmpty()
+	}
+
+	if m.Entries == nil {
+		m.Entries = make(map[string]map[string]*TargetPresets)
+	}
+	m.path = path
+	return &m, nil
+}
+
+// NewEmpty returns a Manager backed by no on-disk file. Save() will
+// fail until the caller assigns a path or constructs the manager via
+// Load/LoadFrom. Used by callers that want a usable manager even when
+// Load returns an error.
+func NewEmpty() *Manager {
+	return newEmpty()
+}
+
+func newEmpty() *Manager {
+	return &Manager{
+		Entries: make(map[string]map[string]*TargetPresets),
+	}
+}
+
+// Save writes the manager to disk atomically (write-then-rename) so a
+// crash mid-write cannot leave a partial file behind. The parent
+// directory is created on demand.
+func (m *Manager) Save() error {
+	if m.path == "" {
+		return errors.New("presets path not set")
+	}
+
+	dir := filepath.Dir(m.path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create cache directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal presets: %w", err)
+	}
+
+	// Atomic write: write to a sibling temp file, then rename. Rename
+	// is atomic on POSIX and on Windows (same volume) per Go 1.5+.
+	tmp := m.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("failed to write presets temp file: %w", err)
+	}
+	if err := os.Rename(tmp, m.path); err != nil {
+		// Clean up the temp file on rename failure to avoid leaving
+		// clutter behind.
+		_ = os.Remove(tmp)
+		return fmt.Errorf("failed to commit presets file: %w", err)
+	}
+	return nil
+}
+
+// List returns all presets for (makefilePath, targetName), sorted with
+// the last-used preset first, then by UpdatedAt descending so the
+// freshest variant always appears near the top.
+func (m *Manager) List(makefilePath, targetName string) []Preset {
+	bucket := m.bucket(makefilePath, targetName)
+	if bucket == nil || len(bucket.Presets) == 0 {
+		return nil
+	}
+
+	out := make([]Preset, len(bucket.Presets))
+	copy(out, bucket.Presets)
+
+	lastUsed := bucket.LastUsedPreset
+	sort.SliceStable(out, func(i, j int) bool {
+		if lastUsed != "" {
+			if out[i].Name == lastUsed && out[j].Name != lastUsed {
+				return true
+			}
+			if out[j].Name == lastUsed && out[i].Name != lastUsed {
+				return false
+			}
+		}
+		return out[i].UpdatedAt.After(out[j].UpdatedAt)
+	})
+	return out
+}
+
+// Get returns the preset matching (makefilePath, targetName, name) by
+// value, along with a found flag. Returning by value keeps callers
+// from accidentally mutating the manager's internal state.
+func (m *Manager) Get(makefilePath, targetName, name string) (Preset, bool) {
+	bucket := m.bucket(makefilePath, targetName)
+	if bucket == nil {
+		return Preset{}, false
+	}
+	for _, p := range bucket.Presets {
+		if p.Name == name {
+			return p, true
+		}
+	}
+	return Preset{}, false
+}
+
+// Exists reports whether (makefilePath, targetName, name) is already
+// taken. The TUI uses this to decide between "save new" and "prompt
+// for overwrite confirmation".
+func (m *Manager) Exists(makefilePath, targetName, name string) bool {
+	_, ok := m.Get(makefilePath, targetName, name)
+	return ok
+}
+
+// Upsert creates the preset if absent, otherwise updates the existing
+// one in place. The created return value tells the caller which path
+// was taken (useful for status messages). Empty Env/Flags are accepted
+// and round-trip as nil.
+func (m *Manager) Upsert(makefilePath, targetName string, p Preset) (created bool) {
+	now := time.Now()
+	p.Name = strings.TrimSpace(p.Name)
+	if p.Env != nil && len(p.Env) == 0 {
+		p.Env = nil
+	}
+	if p.Flags != nil && len(p.Flags) == 0 {
+		p.Flags = nil
+	}
+
+	bucket := m.ensureBucket(makefilePath, targetName)
+	for i := range bucket.Presets {
+		if bucket.Presets[i].Name == p.Name {
+			// Preserve original CreatedAt to keep the audit trail intact.
+			bucket.Presets[i].Env = p.Env
+			bucket.Presets[i].Flags = p.Flags
+			bucket.Presets[i].UpdatedAt = now
+			return false
+		}
+	}
+	if p.CreatedAt.IsZero() {
+		p.CreatedAt = now
+	}
+	p.UpdatedAt = now
+	bucket.Presets = append(bucket.Presets, p)
+	return true
+}
+
+// UpsertStrict refuses to overwrite an existing preset. It returns
+// ErrPresetExists in that case so the TUI can branch into an overwrite
+// confirmation flow.
+func (m *Manager) UpsertStrict(makefilePath, targetName string, p Preset) error {
+	if m.Exists(makefilePath, targetName, p.Name) {
+		return ErrPresetExists
+	}
+	m.Upsert(makefilePath, targetName, p)
+	return nil
+}
+
+// Delete removes the named preset and reports whether anything was
+// actually deleted. If the deleted preset was the LastUsedPreset, the
+// pointer is cleared so a stale name doesn't linger.
+func (m *Manager) Delete(makefilePath, targetName, name string) bool {
+	bucket := m.bucket(makefilePath, targetName)
+	if bucket == nil {
+		return false
+	}
+	for i := range bucket.Presets {
+		if bucket.Presets[i].Name == name {
+			bucket.Presets = append(bucket.Presets[:i], bucket.Presets[i+1:]...)
+			if bucket.LastUsedPreset == name {
+				bucket.LastUsedPreset = ""
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// MarkUsed updates LastUsedAt on the preset and pins it as the
+// LastUsedPreset for its target so the "R" rerun hotkey can find it.
+// Returns false when the preset doesn't exist (caller decides what to
+// do — typically nothing).
+func (m *Manager) MarkUsed(makefilePath, targetName, name string) bool {
+	bucket := m.bucket(makefilePath, targetName)
+	if bucket == nil {
+		return false
+	}
+	for i := range bucket.Presets {
+		if bucket.Presets[i].Name == name {
+			bucket.Presets[i].LastUsedAt = time.Now()
+			bucket.LastUsedPreset = name
+			return true
+		}
+	}
+	return false
+}
+
+// LastUsed returns the last-used preset for (makefilePath, targetName)
+// when one is recorded and still exists. The pointer is reset on
+// delete, so a non-empty LastUsedPreset always resolves.
+func (m *Manager) LastUsed(makefilePath, targetName string) (Preset, bool) {
+	bucket := m.bucket(makefilePath, targetName)
+	if bucket == nil || bucket.LastUsedPreset == "" {
+		return Preset{}, false
+	}
+	return m.Get(makefilePath, targetName, bucket.LastUsedPreset)
+}
+
+// Count returns the number of presets registered for (makefilePath,
+// targetName). Cheap query for "N presets available" hints in the UI.
+func (m *Manager) Count(makefilePath, targetName string) int {
+	bucket := m.bucket(makefilePath, targetName)
+	if bucket == nil {
+		return 0
+	}
+	return len(bucket.Presets)
+}
+
+// bucket returns the existing bucket or nil — never auto-creates.
+// Used by read-only operations.
+func (m *Manager) bucket(makefilePath, targetName string) *TargetPresets {
+	if m == nil || m.Entries == nil {
+		return nil
+	}
+	byTarget, ok := m.Entries[makefilePath]
+	if !ok {
+		return nil
+	}
+	return byTarget[targetName]
+}
+
+// ensureBucket returns the existing bucket or creates an empty one.
+// Used by write operations.
+func (m *Manager) ensureBucket(makefilePath, targetName string) *TargetPresets {
+	if m.Entries == nil {
+		m.Entries = make(map[string]map[string]*TargetPresets)
+	}
+	byTarget, ok := m.Entries[makefilePath]
+	if !ok {
+		byTarget = make(map[string]*TargetPresets)
+		m.Entries[makefilePath] = byTarget
+	}
+	bucket, ok := byTarget[targetName]
+	if !ok {
+		bucket = &TargetPresets{}
+		byTarget[targetName] = bucket
+	}
+	return bucket
+}
+
+// getCachePath returns the platform-appropriate path to presets.json.
+// It prefers os.UserCacheDir() and falls back to ~/.cache to stay
+// consistent with internal/history/history.go.
+func getCachePath() (string, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		home, herr := os.UserHomeDir()
+		if herr != nil {
+			return "", herr
+		}
+		cacheDir = filepath.Join(home, ".cache")
+	}
+	return filepath.Join(cacheDir, "lazymake", presetsFileName), nil
+}

--- a/internal/presets/presets_test.go
+++ b/internal/presets/presets_test.go
@@ -1,0 +1,249 @@
+package presets
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+const (
+	mfA   = "/tmp/projectA/Makefile"
+	mfB   = "/tmp/projectB/Makefile"
+	tgBld = "build"
+	tgDep = "deploy"
+)
+
+// newTempManager returns a Manager backed by a path inside t.TempDir().
+// Tests use this everywhere so they can mutate and Save() without
+// touching the real cache directory.
+func newTempManager(t *testing.T) *Manager {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "presets.json")
+	mgr, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	return mgr
+}
+
+func TestLoadFrom_MissingFileReturnsEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does-not-exist.json")
+	mgr, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("expected no error for missing file, got %v", err)
+	}
+	if mgr == nil {
+		t.Fatal("expected non-nil manager")
+	}
+	if mgr.Entries == nil {
+		t.Error("expected Entries to be initialized")
+	}
+	if got := mgr.Count(mfA, tgBld); got != 0 {
+		t.Errorf("expected 0 presets, got %d", got)
+	}
+}
+
+func TestLoadFrom_CorruptJSONReturnsEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.json")
+	if err := os.WriteFile(path, []byte("{not valid json"), 0o600); err != nil {
+		t.Fatalf("write corrupt file: %v", err)
+	}
+	mgr, _ := LoadFrom(path)
+	if mgr == nil || mgr.Entries == nil {
+		t.Fatal("expected usable manager with empty Entries on corrupt JSON")
+	}
+	// And we should be able to write a fresh file on top of it.
+	mgr.Upsert(mfA, tgBld, Preset{Name: "p1"})
+	if err := mgr.Save(); err != nil {
+		t.Fatalf("save after corrupt load: %v", err)
+	}
+}
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "presets.json")
+	mgr, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+
+	mgr.Upsert(mfA, tgBld, Preset{
+		Name:  "fast",
+		Env:   map[string]string{"FOO": "1"},
+		Flags: []string{"-j4"},
+	})
+	mgr.Upsert(mfA, tgDep, Preset{
+		Name:  "prod",
+		Env:   map[string]string{"ENV": "prod"},
+		Flags: nil,
+	})
+	if !mgr.MarkUsed(mfA, tgBld, "fast") {
+		t.Fatal("MarkUsed returned false")
+	}
+	if err := mgr.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	mgr2, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("re-load: %v", err)
+	}
+
+	got, ok := mgr2.Get(mfA, tgBld, "fast")
+	if !ok {
+		t.Fatal("preset 'fast' missing after reload")
+	}
+	if !reflect.DeepEqual(got.Env, map[string]string{"FOO": "1"}) {
+		t.Errorf("env mismatch after reload: %v", got.Env)
+	}
+	if !reflect.DeepEqual(got.Flags, []string{"-j4"}) {
+		t.Errorf("flags mismatch after reload: %v", got.Flags)
+	}
+	lu, ok := mgr2.LastUsed(mfA, tgBld)
+	if !ok || lu.Name != "fast" {
+		t.Errorf("expected LastUsed='fast', got %+v ok=%v", lu, ok)
+	}
+
+	// Counts are independent across targets and Makefiles.
+	if got := mgr2.Count(mfA, tgBld); got != 1 {
+		t.Errorf("Count(build)=%d, want 1", got)
+	}
+	if got := mgr2.Count(mfA, tgDep); got != 1 {
+		t.Errorf("Count(deploy)=%d, want 1", got)
+	}
+	if got := mgr2.Count(mfB, tgBld); got != 0 {
+		t.Errorf("Count(projectB/build)=%d, want 0", got)
+	}
+}
+
+func TestUpsert_CreatesThenUpdates(t *testing.T) {
+	mgr := newTempManager(t)
+
+	created := mgr.Upsert(mfA, tgBld, Preset{Name: "p", Env: map[string]string{"A": "1"}})
+	if !created {
+		t.Error("first Upsert should return created=true")
+	}
+	got, _ := mgr.Get(mfA, tgBld, "p")
+	if got.CreatedAt.IsZero() || got.UpdatedAt.IsZero() {
+		t.Error("CreatedAt and UpdatedAt should be set on insert")
+	}
+	origCreated := got.CreatedAt
+
+	// Second upsert with same name → update, CreatedAt preserved.
+	created = mgr.Upsert(mfA, tgBld, Preset{Name: "p", Env: map[string]string{"A": "2"}})
+	if created {
+		t.Error("second Upsert should return created=false")
+	}
+	got, _ = mgr.Get(mfA, tgBld, "p")
+	if got.Env["A"] != "2" {
+		t.Errorf("Env not updated: %v", got.Env)
+	}
+	if !got.CreatedAt.Equal(origCreated) {
+		t.Errorf("CreatedAt mutated on update: %v -> %v", origCreated, got.CreatedAt)
+	}
+	if !got.UpdatedAt.After(origCreated) && !got.UpdatedAt.Equal(origCreated) {
+		// UpdatedAt may be equal in a sub-millisecond run, so just check
+		// it isn't earlier than CreatedAt.
+		t.Errorf("UpdatedAt regressed: %v < %v", got.UpdatedAt, origCreated)
+	}
+}
+
+func TestUpsertStrict_RefusesDuplicate(t *testing.T) {
+	mgr := newTempManager(t)
+
+	if err := mgr.UpsertStrict(mfA, tgBld, Preset{Name: "p"}); err != nil {
+		t.Fatalf("first UpsertStrict: %v", err)
+	}
+	err := mgr.UpsertStrict(mfA, tgBld, Preset{Name: "p"})
+	if !errors.Is(err, ErrPresetExists) {
+		t.Errorf("expected ErrPresetExists, got %v", err)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	mgr := newTempManager(t)
+	mgr.Upsert(mfA, tgBld, Preset{Name: "p1"})
+	mgr.Upsert(mfA, tgBld, Preset{Name: "p2"})
+	mgr.MarkUsed(mfA, tgBld, "p1")
+
+	if !mgr.Delete(mfA, tgBld, "p1") {
+		t.Error("Delete should return true for existing preset")
+	}
+	if mgr.Delete(mfA, tgBld, "p1") {
+		t.Error("Delete should return false for missing preset")
+	}
+	// Deleting the last-used preset clears the pointer.
+	if _, ok := mgr.LastUsed(mfA, tgBld); ok {
+		t.Error("LastUsed should be empty after deleting the last-used preset")
+	}
+	// The other preset still exists.
+	if !mgr.Exists(mfA, tgBld, "p2") {
+		t.Error("Delete removed the wrong preset")
+	}
+}
+
+func TestList_SortsLastUsedFirst(t *testing.T) {
+	mgr := newTempManager(t)
+	mgr.Upsert(mfA, tgBld, Preset{Name: "old"})
+	mgr.Upsert(mfA, tgBld, Preset{Name: "new"})
+	mgr.MarkUsed(mfA, tgBld, "old")
+
+	got := mgr.List(mfA, tgBld)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 presets, got %d", len(got))
+	}
+	if got[0].Name != "old" {
+		t.Errorf("expected last-used 'old' first, got %q", got[0].Name)
+	}
+	if got[1].Name != "new" {
+		t.Errorf("expected 'new' second, got %q", got[1].Name)
+	}
+}
+
+func TestMarkUsed_MissingPresetReturnsFalse(t *testing.T) {
+	mgr := newTempManager(t)
+	if mgr.MarkUsed(mfA, tgBld, "no-such-preset") {
+		t.Error("MarkUsed should return false for unknown preset")
+	}
+	if _, ok := mgr.LastUsed(mfA, tgBld); ok {
+		t.Error("LastUsed should remain empty after failed MarkUsed")
+	}
+}
+
+func TestEmptyEnvAndFlags_NormalizedToNil(t *testing.T) {
+	mgr := newTempManager(t)
+	mgr.Upsert(mfA, tgBld, Preset{
+		Name:  "blank",
+		Env:   map[string]string{},
+		Flags: []string{},
+	})
+	got, _ := mgr.Get(mfA, tgBld, "blank")
+	if got.Env != nil {
+		t.Errorf("empty Env should normalize to nil, got %v", got.Env)
+	}
+	if got.Flags != nil {
+		t.Errorf("empty Flags should normalize to nil, got %v", got.Flags)
+	}
+}
+
+func TestSaveAtomic_NoStalePresetsOnTempFailure(t *testing.T) {
+	// We can't easily simulate a write failure portably, but we can at
+	// least assert the .tmp file is cleaned up on success.
+	path := filepath.Join(t.TempDir(), "presets.json")
+	mgr, _ := LoadFrom(path)
+	mgr.Upsert(mfA, tgBld, Preset{Name: "p"})
+	if err := mgr.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf("expected temp file to be removed after Save, stat err=%v", err)
+	}
+}
+
+func TestSave_FailsWithoutPath(t *testing.T) {
+	mgr := NewEmpty()
+	if err := mgr.Save(); err == nil {
+		t.Error("Save should fail when path is unset")
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rshelekhov/lazymake/internal/highlight"
 	"github.com/rshelekhov/lazymake/internal/history"
 	"github.com/rshelekhov/lazymake/internal/makefile"
+	"github.com/rshelekhov/lazymake/internal/presets"
 	"github.com/rshelekhov/lazymake/internal/safety"
 	"github.com/rshelekhov/lazymake/internal/shell"
 	"github.com/rshelekhov/lazymake/internal/variables"
@@ -38,13 +39,32 @@ const (
 	StateConfirmDangerous
 	StateVariables
 	StateWorkspace
-	StateRunParams // Interactive form for env vars and make flags (issue #37)
+	StateRunParams   // Interactive form for env vars and make flags (issue #37)
+	StateRunPresets  // Saved presets picker for a target (issue #35)
 )
 
 // Indices for the focused field in the run-params form.
 const (
 	paramsFieldEnv   = 0
 	paramsFieldFlags = 1
+)
+
+// Sub-modes inside StateRunParams. The form ↔ save-name prompt ↔
+// overwrite confirmation transitions stay inside StateRunParams so we
+// don't proliferate top-level AppState values for what is essentially
+// a wizard flow.
+const (
+	paramsSubModeForm              = 0
+	paramsSubModeSaveName          = 1
+	paramsSubModeOverwriteConfirm  = 2
+)
+
+// Sub-modes inside StateRunPresets. The picker pivots between the
+// main list and a delete confirmation overlay; both share the same
+// container so escape always returns to the list cleanly.
+const (
+	presetsSubModeList          = 0
+	presetsSubModeDeleteConfirm = 1
 )
 
 type Model struct {
@@ -112,6 +132,43 @@ type Model struct {
 	// so the output view can display the env/flags that were used even
 	// after CurrentRunOpts is cleared.
 	LastRunOpts executor.ExecutionOptions
+
+	// Saved run presets (issue #35). Presets is the on-disk store of
+	// named (env, flags) configurations; it may be nil if Load() failed
+	// at startup — every caller must nil-check before use to keep the
+	// app running gracefully without persistent presets.
+	//
+	// PresetsItems/PresetsCursor are the visible UI state for the
+	// picker; rebuilt every time the picker opens so additions or
+	// deletes don't strand a stale snapshot.
+	//
+	// PresetsTarget pins the target the picker was opened for so list
+	// navigation behind the picker doesn't change what gets executed.
+	//
+	// PresetsReturnTo decides where Enter/Esc lands: when opened from
+	// the list it's StateList (Enter starts execution); when opened
+	// from the params form via Ctrl+P it's StateRunParams (Enter
+	// populates the form inputs and returns there).
+	//
+	// PresetsSubMode toggles between the main list and a delete
+	// confirmation overlay; PresetsPendingDelete stores the name of
+	// the preset awaiting confirmation.
+	//
+	// ParamsSubMode + PresetNameInput drive the save-as-preset wizard
+	// that lives inside StateRunParams. PendingPresetName carries the
+	// typed name into the overwrite confirmation step.
+	Presets             *presets.Manager
+	PresetsItems        []presets.Preset
+	PresetsCursor       int
+	PresetsTarget       *Target
+	PresetsReturnTo     AppState
+	PresetsError        string
+	PresetsStatus       string // transient success message (e.g. after save)
+	PresetsSubMode      int
+	PresetsPendingDelete string
+	ParamsSubMode       int
+	PresetNameInput     textinput.Model
+	PendingPresetName   string
 
 	// Execution timing
 	ExecutionStartTime time.Time
@@ -289,6 +346,14 @@ func NewModel(cfg *config.Config) Model {
 		key.NewBinding(
 			key.WithKeys("e"),
 			key.WithHelp("e", "run with params"),
+		),
+		key.NewBinding(
+			key.WithKeys("p"),
+			key.WithHelp("p", "presets"),
+		),
+		key.NewBinding(
+			key.WithKeys("R"),
+			key.WithHelp("R", "rerun last preset"),
 		),
 		key.NewBinding(
 			key.WithKeys("/"),
@@ -479,6 +544,10 @@ func (m Model) SwitchWorkspace(newMakefilePath string, cfg *config.Config) Model
 	newModel.Width = m.Width
 	newModel.Height = m.Height
 	newModel.WorkspaceManager = m.WorkspaceManager
+	// Presets is a global store keyed by absolute Makefile path, so
+	// the same manager works for the new workspace — preserving it
+	// avoids re-reading presets.json on every workspace switch.
+	newModel.Presets = m.Presets
 
 	// Initialize recipe viewport if dimensions are available
 	if newModel.Width > 0 && newModel.Height > 0 {

--- a/internal/tui/params.go
+++ b/internal/tui/params.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -140,4 +141,47 @@ func shellSplit(s string) ([]string, error) {
 	}
 	flush()
 	return tokens, nil
+}
+
+// formatEnvRaw serializes a parsed env map back into the raw textinput
+// format. Keys are sorted to make the result deterministic and stable
+// across saves; values containing whitespace are double-quoted to
+// round-trip through parseEnvLine.
+//
+// Returns "" for an empty/nil map so the textinput shows its
+// placeholder instead of a blank string of quotes.
+func formatEnvRaw(env map[string]string) string {
+	if len(env) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		v := env[k]
+		if strings.ContainsAny(v, " \t\"") {
+			// Escape embedded double quotes by stripping them — the
+			// textinput parser doesn't support escapes, so this is
+			// the closest we can do without breaking round-trip.
+			v = strings.ReplaceAll(v, `"`, "")
+			parts = append(parts, k+`="`+v+`"`)
+			continue
+		}
+		parts = append(parts, k+"="+v)
+	}
+	return strings.Join(parts, " ")
+}
+
+// formatFlagsRaw serializes a parsed flags slice back into the raw
+// textinput format. Flags don't carry whitespace today, so a plain
+// space-join suffices; the helper exists for symmetry with
+// formatEnvRaw and to centralize this rule.
+func formatFlagsRaw(flags []string) string {
+	if len(flags) == 0 {
+		return ""
+	}
+	return strings.Join(flags, " ")
 }

--- a/internal/tui/params_test.go
+++ b/internal/tui/params_test.go
@@ -236,6 +236,85 @@ func TestParamsTabTogglesFocus(t *testing.T) {
 	}
 }
 
+func TestFormatEnvRaw(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]string
+		want string
+	}{
+		{name: "empty", in: nil, want: ""},
+		{name: "zero len", in: map[string]string{}, want: ""},
+		{name: "single", in: map[string]string{"FOO": "bar"}, want: "FOO=bar"},
+		{
+			name: "sorted by key",
+			in:   map[string]string{"B": "2", "A": "1", "C": "3"},
+			want: "A=1 B=2 C=3",
+		},
+		{
+			name: "value with space gets quoted",
+			in:   map[string]string{"MSG": "hello world"},
+			want: `MSG="hello world"`,
+		},
+		{
+			name: "value with embedded quote",
+			in:   map[string]string{"X": `a"b`},
+			// The current parser doesn't support quote escapes, so we
+			// strip them rather than emit something parseEnvLine would
+			// reject when the user re-opens the form.
+			want: `X="ab"`,
+		},
+		{
+			name: "empty value preserved",
+			in:   map[string]string{"E": ""},
+			want: "E=",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatEnvRaw(tt.in)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatEnvRaw_RoundTripsThroughParseEnvLine(t *testing.T) {
+	in := map[string]string{
+		"FOO":   "bar",
+		"MSG":   "hello world",
+		"EMPTY": "",
+	}
+	got, err := parseEnvLine(formatEnvRaw(in))
+	if err != nil {
+		t.Fatalf("re-parse failed: %v", err)
+	}
+	if !reflect.DeepEqual(got, in) {
+		t.Errorf("round-trip mismatch:\n  got  %v\n  want %v", got, in)
+	}
+}
+
+func TestFormatFlagsRaw(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{name: "empty", in: nil, want: ""},
+		{name: "zero len", in: []string{}, want: ""},
+		{name: "single", in: []string{"-j4"}, want: "-j4"},
+		{name: "multiple", in: []string{"-j4", "-k", "--always-make"}, want: "-j4 -k --always-make"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatFlagsRaw(tt.in)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestParamsPrefillsFromLastRunParams verifies opening the form for a
 // target that was previously run with params restores those values.
 func TestParamsPrefillsFromLastRunParams(t *testing.T) {

--- a/internal/tui/presets_test.go
+++ b/internal/tui/presets_test.go
@@ -1,0 +1,402 @@
+package tui
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/rshelekhov/lazymake/internal/history"
+	"github.com/rshelekhov/lazymake/internal/presets"
+)
+
+// makePresetsTestModel mirrors makeParamsTestModel but additionally
+// wires a real presets.Manager pointed at t.TempDir(). The List is
+// seeded with a single "build" target so handleOpenPresetsPicker and
+// handleRerunLastUsed both have something to operate on.
+func makePresetsTestModel(t *testing.T) Model {
+	t.Helper()
+
+	presetsPath := filepath.Join(t.TempDir(), "presets.json")
+	pmgr, err := presets.LoadFrom(presetsPath)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+
+	target := Target{Name: "build"}
+	l := list.New([]list.Item{target}, NewItemDelegate(), 0, 0)
+	l.Select(0)
+
+	return Model{
+		List:            l,
+		History:         &history.History{Entries: make(map[string][]history.Entry)},
+		MakefilePath:    "/tmp/test-Makefile",
+		StreamingOutput: &strings.Builder{},
+		LastRunParams:   make(map[string]ExecutionParams),
+		Targets:         []Target{target},
+		AllTargets:      []Target{target},
+		Presets:         pmgr,
+	}
+}
+
+// TestPresetsPickerOpensFromList: pressing 'p' (via handleOpenPresetsPicker)
+// flips state to StateRunPresets and snapshots the list of presets.
+func TestPresetsPickerOpensFromList(t *testing.T) {
+	m := makePresetsTestModel(t)
+	m.Presets.Upsert(m.MakefilePath, "build", presets.Preset{
+		Name:  "fast",
+		Flags: []string{"-j4"},
+	})
+
+	updated, _ := m.handleOpenPresetsPicker()
+	mm := updated.(Model)
+
+	if mm.State != StateRunPresets {
+		t.Errorf("state=%v, want StateRunPresets", mm.State)
+	}
+	if mm.PresetsTarget == nil || mm.PresetsTarget.Name != "build" {
+		t.Errorf("expected PresetsTarget=build, got %+v", mm.PresetsTarget)
+	}
+	if mm.PresetsReturnTo != StateList {
+		t.Errorf("PresetsReturnTo=%v, want StateList", mm.PresetsReturnTo)
+	}
+	if len(mm.PresetsItems) != 1 || mm.PresetsItems[0].Name != "fast" {
+		t.Errorf("PresetsItems=%+v, want [fast]", mm.PresetsItems)
+	}
+}
+
+// TestPresetsPickerEnterRunsTarget: Enter on a preset row marks it as
+// last-used, populates CurrentRunOpts, and transitions to execution.
+func TestPresetsPickerEnterRunsTarget(t *testing.T) {
+	m := makePresetsTestModel(t)
+	m.Presets.Upsert(m.MakefilePath, "build", presets.Preset{
+		Name:  "fast",
+		Env:   map[string]string{"FOO": "bar"},
+		Flags: []string{"-j4"},
+	})
+	updated, _ := m.handleOpenPresetsPicker()
+	mm := updated.(Model)
+
+	updated, _ = mm.updateRunPresets(tea.KeyMsg{Type: tea.KeyEnter})
+	mm = updated.(Model)
+
+	if mm.State != StateExecuting {
+		t.Errorf("state=%v, want StateExecuting after Enter on preset", mm.State)
+	}
+	if mm.CurrentRunOpts.Env["FOO"] != "bar" {
+		t.Errorf("CurrentRunOpts.Env mismatch: %v", mm.CurrentRunOpts.Env)
+	}
+	if len(mm.CurrentRunOpts.Flags) != 1 || mm.CurrentRunOpts.Flags[0] != "-j4" {
+		t.Errorf("CurrentRunOpts.Flags mismatch: %v", mm.CurrentRunOpts.Flags)
+	}
+	if lu, ok := mm.Presets.LastUsed(mm.MakefilePath, "build"); !ok || lu.Name != "fast" {
+		t.Errorf("LastUsed=%+v ok=%v, want fast/true", lu, ok)
+	}
+}
+
+// TestPresetsDeleteWithConfirmation: 'd' enters confirm sub-mode, 'y'
+// removes the preset and saves; 'n' cancels.
+func TestPresetsDeleteWithConfirmation(t *testing.T) {
+	m := makePresetsTestModel(t)
+	m.Presets.Upsert(m.MakefilePath, "build", presets.Preset{Name: "old"})
+	m.Presets.Upsert(m.MakefilePath, "build", presets.Preset{Name: "keep"})
+
+	updated, _ := m.handleOpenPresetsPicker()
+	mm := updated.(Model)
+
+	// Cursor starts at 0; the first preset in the picker is the
+	// most-recently-updated one. We don't care which name appears
+	// first, but we DO want to assert the delete pipeline removes
+	// whatever the cursor points at.
+	cursorName := mm.PresetsItems[mm.PresetsCursor].Name
+
+	updated, _ = mm.updateRunPresets(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	mm = updated.(Model)
+	if mm.PresetsSubMode != presetsSubModeDeleteConfirm {
+		t.Fatalf("expected delete-confirm sub-mode, got %d", mm.PresetsSubMode)
+	}
+	if mm.PresetsPendingDelete != cursorName {
+		t.Errorf("PendingDelete=%q, want %q", mm.PresetsPendingDelete, cursorName)
+	}
+
+	// Confirm with 'y'.
+	updated, _ = mm.updateRunPresets(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	mm = updated.(Model)
+	if mm.PresetsSubMode != presetsSubModeList {
+		t.Errorf("expected list sub-mode after confirm, got %d", mm.PresetsSubMode)
+	}
+	if mm.Presets.Exists(mm.MakefilePath, "build", cursorName) {
+		t.Errorf("preset %q still exists after delete-confirm", cursorName)
+	}
+	if got := mm.Presets.Count(mm.MakefilePath, "build"); got != 1 {
+		t.Errorf("Count=%d after delete, want 1", got)
+	}
+}
+
+// TestPresetsDeleteCanceled: pressing 'n' in confirm leaves the preset
+// untouched and returns to the list.
+func TestPresetsDeleteCanceled(t *testing.T) {
+	m := makePresetsTestModel(t)
+	m.Presets.Upsert(m.MakefilePath, "build", presets.Preset{Name: "p"})
+	updated, _ := m.handleOpenPresetsPicker()
+	mm := updated.(Model)
+	updated, _ = mm.updateRunPresets(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	mm = updated.(Model)
+	updated, _ = mm.updateRunPresets(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	mm = updated.(Model)
+
+	if mm.PresetsSubMode != presetsSubModeList {
+		t.Errorf("expected list sub-mode after cancel, got %d", mm.PresetsSubMode)
+	}
+	if !mm.Presets.Exists(mm.MakefilePath, "build", "p") {
+		t.Error("preset was deleted despite cancel")
+	}
+}
+
+// TestPresetsSaveFromParamsForm: Ctrl+S → type name → Enter saves the
+// preset and returns to the form with a success message.
+func TestPresetsSaveFromParamsForm(t *testing.T) {
+	m := makePresetsTestModel(t)
+	target := Target{Name: "build"}
+	m.initParamsForm(&target)
+	m.State = StateRunParams
+	m.ParamsEnvInput.SetValue("FOO=bar")
+	m.ParamsFlagsInput.SetValue("-j4")
+
+	// Ctrl+S is delivered as tea.KeyCtrlS (msg.String() == "ctrl+s").
+	updated, _ := m.updateRunParams(tea.KeyMsg{Type: tea.KeyCtrlS})
+	mm := updated.(Model)
+	if mm.ParamsSubMode != paramsSubModeSaveName {
+		t.Fatalf("expected SaveName sub-mode after Ctrl+S, got %d", mm.ParamsSubMode)
+	}
+
+	// Type a name into the prompt.
+	mm.PresetNameInput.SetValue("fast")
+
+	// Enter to commit.
+	updated, _ = mm.updateRunParams(tea.KeyMsg{Type: tea.KeyEnter})
+	mm = updated.(Model)
+	if mm.ParamsSubMode != paramsSubModeForm {
+		t.Errorf("expected back to form sub-mode, got %d", mm.ParamsSubMode)
+	}
+	if !mm.Presets.Exists(mm.MakefilePath, "build", "fast") {
+		t.Error("preset 'fast' was not saved")
+	}
+	got, _ := mm.Presets.Get(mm.MakefilePath, "build", "fast")
+	if got.Env["FOO"] != "bar" {
+		t.Errorf("preset Env mismatch: %v", got.Env)
+	}
+	if len(got.Flags) != 1 || got.Flags[0] != "-j4" {
+		t.Errorf("preset Flags mismatch: %v", got.Flags)
+	}
+}
+
+// TestPresetsSaveOverwritePromptYes: saving with an existing name
+// shifts to overwrite confirm; 'y' overwrites.
+func TestPresetsSaveOverwritePromptYes(t *testing.T) {
+	m := makePresetsTestModel(t)
+	m.Presets.Upsert(m.MakefilePath, "build", presets.Preset{
+		Name: "fast",
+		Env:  map[string]string{"OLD": "1"},
+	})
+	target := Target{Name: "build"}
+	m.initParamsForm(&target)
+	m.State = StateRunParams
+	m.ParamsEnvInput.SetValue("NEW=2")
+
+	updated, _ := m.updateRunParams(tea.KeyMsg{Type: tea.KeyCtrlS})
+	mm := updated.(Model)
+	mm.PresetNameInput.SetValue("fast")
+
+	updated, _ = mm.updateRunParams(tea.KeyMsg{Type: tea.KeyEnter})
+	mm = updated.(Model)
+	if mm.ParamsSubMode != paramsSubModeOverwriteConfirm {
+		t.Fatalf("expected OverwriteConfirm sub-mode, got %d", mm.ParamsSubMode)
+	}
+
+	updated, _ = mm.updateRunParams(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	mm = updated.(Model)
+	if mm.ParamsSubMode != paramsSubModeForm {
+		t.Errorf("expected back to form sub-mode after overwrite, got %d", mm.ParamsSubMode)
+	}
+	got, _ := mm.Presets.Get(mm.MakefilePath, "build", "fast")
+	if _, ok := got.Env["OLD"]; ok {
+		t.Errorf("old env still present after overwrite: %v", got.Env)
+	}
+	if got.Env["NEW"] != "2" {
+		t.Errorf("new env missing after overwrite: %v", got.Env)
+	}
+}
+
+// TestPresetsSaveOverwritePromptNo: 'n' in overwrite confirm bounces
+// back to the name prompt without writing.
+func TestPresetsSaveOverwritePromptNo(t *testing.T) {
+	m := makePresetsTestModel(t)
+	m.Presets.Upsert(m.MakefilePath, "build", presets.Preset{Name: "fast", Env: map[string]string{"OLD": "1"}})
+	target := Target{Name: "build"}
+	m.initParamsForm(&target)
+	m.State = StateRunParams
+	m.ParamsEnvInput.SetValue("NEW=2")
+	updated, _ := m.updateRunParams(tea.KeyMsg{Type: tea.KeyCtrlS})
+	mm := updated.(Model)
+	mm.PresetNameInput.SetValue("fast")
+	updated, _ = mm.updateRunParams(tea.KeyMsg{Type: tea.KeyEnter})
+	mm = updated.(Model)
+
+	updated, _ = mm.updateRunParams(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	mm = updated.(Model)
+
+	if mm.ParamsSubMode != paramsSubModeSaveName {
+		t.Errorf("expected SaveName after 'n', got %d", mm.ParamsSubMode)
+	}
+	got, _ := mm.Presets.Get(mm.MakefilePath, "build", "fast")
+	if got.Env["OLD"] != "1" || got.Env["NEW"] == "2" {
+		t.Errorf("preset mutated despite cancel: %v", got.Env)
+	}
+}
+
+// TestPresetsSaveValidatesFirst: Ctrl+S with malformed env input
+// reports the error and does NOT enter the save-name sub-mode.
+func TestPresetsSaveValidatesFirst(t *testing.T) {
+	m := makePresetsTestModel(t)
+	target := Target{Name: "build"}
+	m.initParamsForm(&target)
+	m.State = StateRunParams
+	m.ParamsEnvInput.SetValue("not-an-env-pair")
+
+	updated, _ := m.updateRunParams(tea.KeyMsg{Type: tea.KeyCtrlS})
+	mm := updated.(Model)
+
+	if mm.ParamsSubMode != paramsSubModeForm {
+		t.Errorf("expected to stay in form on validation error, got %d", mm.ParamsSubMode)
+	}
+	if mm.ParamsError == "" {
+		t.Error("expected ParamsError to be set on invalid env")
+	}
+}
+
+// TestPresetsLoadFromParamsForm: Ctrl+P opens the picker with
+// PresetsReturnTo=StateRunParams; selecting a preset populates the
+// form and returns there.
+func TestPresetsLoadFromParamsForm(t *testing.T) {
+	m := makePresetsTestModel(t)
+	m.Presets.Upsert(m.MakefilePath, "build", presets.Preset{
+		Name:  "fast",
+		Env:   map[string]string{"FOO": "bar"},
+		Flags: []string{"-j4"},
+	})
+	target := Target{Name: "build"}
+	m.initParamsForm(&target)
+	m.State = StateRunParams
+
+	updated, _ := m.updateRunParams(tea.KeyMsg{Type: tea.KeyCtrlP})
+	mm := updated.(Model)
+	if mm.State != StateRunPresets {
+		t.Fatalf("expected StateRunPresets after Ctrl+P, got %v", mm.State)
+	}
+	if mm.PresetsReturnTo != StateRunParams {
+		t.Errorf("PresetsReturnTo=%v, want StateRunParams", mm.PresetsReturnTo)
+	}
+
+	updated, _ = mm.updateRunPresets(tea.KeyMsg{Type: tea.KeyEnter})
+	mm = updated.(Model)
+	if mm.State != StateRunParams {
+		t.Errorf("expected return to StateRunParams, got %v", mm.State)
+	}
+	if mm.ParamsEnvInput.Value() != "FOO=bar" {
+		t.Errorf("env not populated: %q", mm.ParamsEnvInput.Value())
+	}
+	if mm.ParamsFlagsInput.Value() != "-j4" {
+		t.Errorf("flags not populated: %q", mm.ParamsFlagsInput.Value())
+	}
+}
+
+// TestRerunLastUsed: 'R' picks the last-used preset for the cursor
+// target and starts execution.
+func TestRerunLastUsed(t *testing.T) {
+	m := makePresetsTestModel(t)
+	m.Presets.Upsert(m.MakefilePath, "build", presets.Preset{
+		Name:  "fast",
+		Env:   map[string]string{"E": "1"},
+		Flags: []string{"-j2"},
+	})
+	m.Presets.MarkUsed(m.MakefilePath, "build", "fast")
+
+	updated, _ := m.handleRerunLastUsed()
+	mm := updated.(Model)
+
+	if mm.State != StateExecuting {
+		t.Errorf("expected StateExecuting after R, got %v", mm.State)
+	}
+	if mm.CurrentRunOpts.Env["E"] != "1" {
+		t.Errorf("CurrentRunOpts not populated from preset: %+v", mm.CurrentRunOpts)
+	}
+}
+
+// TestRerunLastUsed_NoPresetNoOp: 'R' is a no-op when there's no
+// last-used preset — never crashes, never transitions state.
+func TestRerunLastUsed_NoPresetNoOp(t *testing.T) {
+	m := makePresetsTestModel(t)
+	updated, _ := m.handleRerunLastUsed()
+	mm := updated.(Model)
+	if mm.State != m.State {
+		t.Errorf("expected no state change, got %v", mm.State)
+	}
+}
+
+// TestPresetsPickerEscReturnsToOpenerState: Esc returns to the state
+// that originally opened the picker (StateList or StateRunParams).
+func TestPresetsPickerEscReturnsToOpenerState(t *testing.T) {
+	m := makePresetsTestModel(t)
+	updated, _ := m.handleOpenPresetsPicker()
+	mm := updated.(Model)
+	updated, _ = mm.updateRunPresets(tea.KeyMsg{Type: tea.KeyEsc})
+	mm = updated.(Model)
+	if mm.State != StateList {
+		t.Errorf("expected StateList after Esc, got %v", mm.State)
+	}
+}
+
+// TestPresetsForMissingTargetNotShownInList: a preset stored against
+// a target name not present in m.Targets is hidden but NOT deleted
+// (so the user keeps it for when the target comes back). The picker
+// is opened from the current list cursor, which only knows about
+// targets that exist — verifying the absence path is enough.
+func TestPresetsForMissingTargetNotShownInList(t *testing.T) {
+	m := makePresetsTestModel(t)
+	// Store a preset for "deploy", but Targets only contains "build".
+	m.Presets.Upsert(m.MakefilePath, "deploy", presets.Preset{Name: "prod"})
+
+	updated, _ := m.handleOpenPresetsPicker()
+	mm := updated.(Model)
+	for _, p := range mm.PresetsItems {
+		if p.Name == "prod" {
+			t.Errorf("preset for missing target was shown: %+v", p)
+		}
+	}
+	// Confirm the underlying store still has it.
+	if !mm.Presets.Exists(mm.MakefilePath, "deploy", "prod") {
+		t.Error("preset for missing target was deleted; should be kept for future use")
+	}
+}
+
+// TestPresetsPickerDoesNotCrashWithNilManager: a nil Presets manager
+// (Load failed at startup) must not panic when 'p' is pressed.
+func TestPresetsPickerDoesNotCrashWithNilManager(t *testing.T) {
+	m := makePresetsTestModel(t)
+	m.Presets = nil
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("panic: %v", r)
+		}
+	}()
+	updated, _ := m.handleOpenPresetsPicker()
+	mm := updated.(Model)
+	if mm.State != StateRunPresets {
+		t.Errorf("expected picker to open even with nil store, got %v", mm.State)
+	}
+	if len(mm.PresetsItems) != 0 {
+		t.Errorf("expected empty items list, got %d", len(mm.PresetsItems))
+	}
+}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -46,6 +46,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateWorkspace(msg)
 	case StateRunParams:
 		return m.updateRunParams(msg)
+	case StateRunPresets:
+		return m.updateRunPresets(msg)
 	default:
 		return m, nil
 	}
@@ -109,6 +111,10 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleTargetSelection()
 	case "e":
 		return m.handleOpenParamsForm()
+	case "p":
+		return m.handleOpenPresetsPicker()
+	case "R":
+		return m.handleRerunLastUsed()
 	case "ctrl+d":
 		m.RecipeViewport.HalfPageDown()
 		return m, nil

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -115,12 +115,8 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleOpenPresetsPicker()
 	case "R":
 		return m.handleRerunLastUsed()
-	case "ctrl+d":
-		m.RecipeViewport.HalfPageDown()
-		return m, nil
-	case "ctrl+u":
-		m.RecipeViewport.HalfPageUp()
-		return m, nil
+	case "ctrl+d", "ctrl+u":
+		return m.handleRecipeHalfPage(msg.String())
 	case "down", "j":
 		m = navigateToTarget(m, true)
 		m = updateRecipeViewportContent(m)
@@ -140,6 +136,19 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	m = updateRecipeViewportContent(m)
 
 	return m, cmd
+}
+
+// handleRecipeHalfPage scrolls the recipe preview viewport by half a
+// page in the direction requested via the bound ctrl+d / ctrl+u keys.
+// Extracted from handleKeyPress so the dispatcher stays under the
+// gocyclo limit configured in .golangci.yml.
+func (m Model) handleRecipeHalfPage(key string) (tea.Model, tea.Cmd) {
+	if key == "ctrl+d" {
+		m.RecipeViewport.HalfPageDown()
+	} else {
+		m.RecipeViewport.HalfPageUp()
+	}
+	return m, nil
 }
 
 // navigateToTarget moves to next/previous Target, skipping headers and separators

--- a/internal/tui/update_params.go
+++ b/internal/tui/update_params.go
@@ -64,6 +64,12 @@ func (m *Model) initParamsForm(target *Target) {
 	m.ParamsFocus = paramsFieldEnv
 	m.ParamsTarget = target
 	m.ParamsError = ""
+	// Form starts in the normal "type and submit" sub-mode. The
+	// save-as-preset wizard (Ctrl+S) flips this to SaveName, and
+	// commitPresetName may then flip it to OverwriteConfirm.
+	m.ParamsSubMode = paramsSubModeForm
+	m.PendingPresetName = ""
+	m.PresetsStatus = ""
 }
 
 // updateRunParams handles key input while the params form is active.
@@ -72,7 +78,21 @@ func (m *Model) initParamsForm(target *Target) {
 // inputs. Enter parses both fields; on success it stores the parsed
 // values in LastRunParams and m.CurrentRunOpts, then transitions to
 // the executor (or to dangerous confirmation, for critical targets).
+//
+// Ctrl+S enters the save-as-preset wizard, Ctrl+P opens the saved
+// presets picker (issue #35). Both keep the user inside StateRunParams
+// via sub-modes so a cancel-on-error never strands them in a half-open
+// dialog.
 func (m Model) updateRunParams(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// Sub-mode dispatch first — the form's main key handling only
+	// runs when we're in the "type and submit" mode.
+	switch m.ParamsSubMode {
+	case paramsSubModeSaveName:
+		return m.updateParamsSaveName(msg)
+	case paramsSubModeOverwriteConfirm:
+		return m.updateParamsOverwriteConfirm(msg)
+	}
+
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.Type {
@@ -84,9 +104,17 @@ func (m Model) updateRunParams(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.KeyEnter:
 			return m.submitParamsForm()
 		}
-		// Ctrl+C still quits.
-		if msg.String() == "ctrl+c" {
+		switch msg.String() {
+		case "ctrl+c":
 			return m, tea.Quit
+		case "ctrl+s":
+			return m.handleParamsSavePreset()
+		case "ctrl+p":
+			if m.ParamsTarget == nil {
+				return m, nil
+			}
+			target := *m.ParamsTarget
+			return m.openPresetsPicker(&target, StateRunParams), nil
 		}
 	case tea.WindowSizeMsg:
 		m.Width = msg.Width
@@ -118,6 +146,9 @@ func (m Model) cancelParamsForm() Model {
 	m.State = StateList
 	m.ParamsTarget = nil
 	m.ParamsError = ""
+	m.ParamsSubMode = paramsSubModeForm
+	m.PendingPresetName = ""
+	m.PresetsStatus = ""
 	return m
 }
 

--- a/internal/tui/update_presets.go
+++ b/internal/tui/update_presets.go
@@ -1,0 +1,435 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/rshelekhov/lazymake/internal/executor"
+	"github.com/rshelekhov/lazymake/internal/presets"
+	"github.com/rshelekhov/lazymake/internal/safety"
+)
+
+// presetNameMaxLen caps preset names so the picker columns stay
+// predictable. 64 is generous for "prod-deploy-eu-west-2" style
+// names without letting users paste a paragraph.
+const presetNameMaxLen = 64
+
+// handleOpenPresetsPicker transitions to the presets picker for the
+// currently selected target. Bound to the "p" key in the list view.
+//
+// The picker shows only presets whose target still exists in the
+// current Makefile; presets for renamed/removed targets stay in the
+// JSON file so they're not lost if the target comes back, but they
+// don't clutter the UI.
+func (m Model) handleOpenPresetsPicker() (tea.Model, tea.Cmd) {
+	selected := m.List.SelectedItem()
+	target, ok := selected.(Target)
+	if !ok {
+		return m, nil
+	}
+	return m.openPresetsPicker(&target, StateList), nil
+}
+
+// openPresetsPicker is the shared entry point used both by the list-
+// view "p" hotkey and by the params-form Ctrl+P. It pins the target
+// and the return state, then snapshots the current list of presets.
+func (m Model) openPresetsPicker(target *Target, returnTo AppState) Model {
+	m.State = StateRunPresets
+	m.PresetsTarget = target
+	m.PresetsReturnTo = returnTo
+	m.PresetsSubMode = presetsSubModeList
+	m.PresetsPendingDelete = ""
+	m.PresetsError = ""
+	m.PresetsStatus = ""
+	m.PresetsCursor = 0
+
+	if m.Presets != nil {
+		m.PresetsItems = m.Presets.List(m.MakefilePath, target.Name)
+	} else {
+		m.PresetsItems = nil
+	}
+	return m
+}
+
+// updateRunPresets handles key input while the presets picker is
+// active. Sub-modes (list vs. delete confirm) are dispatched first
+// so the main switch stays focused on the common case.
+func (m Model) updateRunPresets(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		if keyMsg.String() == "ctrl+c" {
+			return m, tea.Quit
+		}
+		switch m.PresetsSubMode {
+		case presetsSubModeDeleteConfirm:
+			return m.updatePresetsDeleteConfirm(keyMsg)
+		default:
+			return m.updatePresetsList(keyMsg)
+		}
+	}
+	if size, ok := msg.(tea.WindowSizeMsg); ok {
+		m.Width = size.Width
+		m.Height = size.Height
+	}
+	return m, nil
+}
+
+// updatePresetsList handles navigation and actions on the main list
+// of presets for a target.
+func (m Model) updatePresetsList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		return m.cancelPresetsPicker(), nil
+	case "q":
+		return m, tea.Quit
+	case "j", "down":
+		if m.PresetsCursor < len(m.PresetsItems)-1 {
+			m.PresetsCursor++
+		}
+		return m, nil
+	case "k", "up":
+		if m.PresetsCursor > 0 {
+			m.PresetsCursor--
+		}
+		return m, nil
+	case "g":
+		m.PresetsCursor = 0
+		return m, nil
+	case "G":
+		if len(m.PresetsItems) > 0 {
+			m.PresetsCursor = len(m.PresetsItems) - 1
+		}
+		return m, nil
+	case "d":
+		if len(m.PresetsItems) == 0 {
+			return m, nil
+		}
+		m.PresetsPendingDelete = m.PresetsItems[m.PresetsCursor].Name
+		m.PresetsSubMode = presetsSubModeDeleteConfirm
+		return m, nil
+	case "e":
+		// "Edit" loads the preset into the params form so the user can
+		// tweak values and re-save. This is the natural workflow when
+		// you want to derive "prod-eu" from "prod".
+		return m.loadPresetIntoForm()
+	case "enter":
+		return m.handlePresetSelect()
+	}
+	return m, nil
+}
+
+// updatePresetsDeleteConfirm handles the inline "y/n" confirmation
+// shown when the user presses 'd' on a preset.
+func (m Model) updatePresetsDeleteConfirm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "y", "Y", "enter":
+		if m.Presets != nil && m.PresetsTarget != nil {
+			name := m.PresetsPendingDelete
+			if m.Presets.Delete(m.MakefilePath, m.PresetsTarget.Name, name) {
+				_ = m.Presets.Save()
+				m.PresetsStatus = fmt.Sprintf("Deleted preset %q", name)
+				// Refresh the snapshot so the deleted item vanishes
+				// immediately, and keep the cursor inside the new bounds.
+				m.PresetsItems = m.Presets.List(m.MakefilePath, m.PresetsTarget.Name)
+				if m.PresetsCursor >= len(m.PresetsItems) && m.PresetsCursor > 0 {
+					m.PresetsCursor = len(m.PresetsItems) - 1
+				}
+			}
+		}
+		m.PresetsSubMode = presetsSubModeList
+		m.PresetsPendingDelete = ""
+		return m, nil
+	case "n", "N", "esc":
+		m.PresetsSubMode = presetsSubModeList
+		m.PresetsPendingDelete = ""
+		return m, nil
+	}
+	return m, nil
+}
+
+// cancelPresetsPicker routes Esc back to the state that opened the
+// picker (list or params form), clearing transient picker state.
+func (m Model) cancelPresetsPicker() Model {
+	returnTo := m.PresetsReturnTo
+	if returnTo == 0 && m.State == StateRunPresets {
+		returnTo = StateList
+	}
+	m.State = returnTo
+	m.PresetsTarget = nil
+	m.PresetsPendingDelete = ""
+	m.PresetsSubMode = presetsSubModeList
+	m.PresetsError = ""
+	m.PresetsStatus = ""
+	return m
+}
+
+// handlePresetSelect handles Enter on a preset row. The destination
+// depends on where the picker was opened from:
+//   - StateList → start execution with the preset's env/flags (and
+//     mark it as last-used so 'R' picks it up later).
+//   - StateRunParams → populate the form inputs and return to it so
+//     the user can tweak before running.
+func (m Model) handlePresetSelect() (tea.Model, tea.Cmd) {
+	if len(m.PresetsItems) == 0 || m.PresetsTarget == nil {
+		return m, nil
+	}
+	p := m.PresetsItems[m.PresetsCursor]
+
+	if m.PresetsReturnTo == StateRunParams {
+		return m.applyPresetToParamsForm(p), nil
+	}
+	return m.runWithPreset(*m.PresetsTarget, p)
+}
+
+// loadPresetIntoForm opens the params form pre-filled with the
+// currently selected preset's values. Used by the "e" key on a preset
+// row. The form is opened in "return to picker" mode? No — opening
+// the params form replaces the picker on the state stack, which is
+// the more useful behavior for an edit-then-save workflow.
+func (m Model) loadPresetIntoForm() (tea.Model, tea.Cmd) {
+	if len(m.PresetsItems) == 0 || m.PresetsTarget == nil {
+		return m, nil
+	}
+	p := m.PresetsItems[m.PresetsCursor]
+	target := *m.PresetsTarget
+
+	m.initParamsForm(&target)
+	// Override the LastRunParams prefill with the preset's values.
+	m.ParamsEnvInput.SetValue(formatEnvRaw(p.Env))
+	m.ParamsFlagsInput.SetValue(formatFlagsRaw(p.Flags))
+	// Carry the name into PendingPresetName so a subsequent Ctrl+S
+	// can default to the same name (and trigger an overwrite prompt).
+	m.PendingPresetName = p.Name
+	m.State = StateRunParams
+	return m, textinput.Blink
+}
+
+// applyPresetToParamsForm fills the params form inputs with the
+// preset's values, then returns to the form so the user can edit.
+// Called when the picker was opened from inside the params form.
+func (m Model) applyPresetToParamsForm(p presets.Preset) Model {
+	m.ParamsEnvInput.SetValue(formatEnvRaw(p.Env))
+	m.ParamsFlagsInput.SetValue(formatFlagsRaw(p.Flags))
+	m.PendingPresetName = p.Name
+	m.ParamsError = ""
+	m.State = StateRunParams
+	m.PresetsTarget = nil
+	m.PresetsPendingDelete = ""
+	m.PresetsSubMode = presetsSubModeList
+	return m
+}
+
+// runWithPreset records the preset as last-used and dispatches to
+// startExecution, taking the same dangerous-confirmation detour as
+// the quick-run path so safety rules apply uniformly.
+func (m Model) runWithPreset(target Target, p presets.Preset) (tea.Model, tea.Cmd) {
+	if m.Presets != nil {
+		m.Presets.MarkUsed(m.MakefilePath, target.Name, p.Name)
+		_ = m.Presets.Save()
+	}
+
+	// Mirror submitParamsForm: cache as the in-session last run so a
+	// subsequent 'e' opens the form pre-filled with the same values.
+	parsed := ExecutionParams{
+		EnvRaw:   formatEnvRaw(p.Env),
+		FlagsRaw: formatFlagsRaw(p.Flags),
+		Env:      p.Env,
+		Flags:    p.Flags,
+	}
+	if m.LastRunParams == nil {
+		m.LastRunParams = make(map[string]ExecutionParams)
+	}
+	m.LastRunParams[target.Name] = parsed
+
+	m.CurrentRunOpts = executor.ExecutionOptions{
+		DryRun: m.DryRun,
+		Env:    p.Env,
+		Flags:  p.Flags,
+	}
+
+	if target.IsDangerous && target.DangerLevel == safety.SeverityCritical {
+		targetCopy := target
+		m.PendingTarget = &targetCopy
+		m.State = StateConfirmDangerous
+		m.PresetsTarget = nil
+		m.PresetsSubMode = presetsSubModeList
+		return m, nil
+	}
+	return m.startExecution(target, m.CurrentRunOpts)
+}
+
+// handleRerunLastUsed runs the last-used preset for the currently
+// selected target, if any. Bound to capital 'R' in the list view.
+// On an empty store / no last-used / missing target the call is a
+// no-op so it never disrupts the list.
+func (m Model) handleRerunLastUsed() (tea.Model, tea.Cmd) {
+	if m.Presets == nil {
+		return m, nil
+	}
+	selected := m.List.SelectedItem()
+	target, ok := selected.(Target)
+	if !ok {
+		return m, nil
+	}
+	p, ok := m.Presets.LastUsed(m.MakefilePath, target.Name)
+	if !ok {
+		return m, nil
+	}
+	return m.runWithPreset(target, p)
+}
+
+// initPresetNameInput primes the textinput for the save-as-preset
+// wizard with the previous PendingPresetName when available, so
+// re-saving an edited preset defaults to the same name.
+func (m *Model) initPresetNameInput() {
+	inputWidth := 60
+	if m.Width > 14 {
+		inputWidth = m.Width - 14
+	}
+	ti := textinput.New()
+	ti.Placeholder = "preset name"
+	ti.Prompt = "NAME  > "
+	ti.CharLimit = presetNameMaxLen
+	ti.Width = inputWidth
+	if m.PendingPresetName != "" {
+		ti.SetValue(m.PendingPresetName)
+	}
+	ti.Focus()
+	m.PresetNameInput = ti
+}
+
+// handleParamsSavePreset transitions the params form into the
+// save-name sub-mode after validating the current env/flags. We
+// validate first so the user can't save a syntactically broken
+// preset that they'd never be able to use.
+func (m Model) handleParamsSavePreset() (tea.Model, tea.Cmd) {
+	if m.ParamsTarget == nil {
+		return m, nil
+	}
+	// Validate the form contents — same checks submitParamsForm runs.
+	if _, err := parseEnvLine(m.ParamsEnvInput.Value()); err != nil {
+		m.ParamsError = err.Error()
+		return m, nil
+	}
+	if _, err := parseFlagsLine(m.ParamsFlagsInput.Value()); err != nil {
+		m.ParamsError = err.Error()
+		return m, nil
+	}
+	m.ParamsError = ""
+	m.initPresetNameInput()
+	m.ParamsSubMode = paramsSubModeSaveName
+	return m, textinput.Blink
+}
+
+// updateParamsSaveName drives the inline "type a preset name" prompt.
+// Esc returns to the form, Enter triggers save (or overwrite-confirm
+// when the name is taken).
+func (m Model) updateParamsSaveName(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		switch keyMsg.Type {
+		case tea.KeyEsc:
+			m.ParamsSubMode = paramsSubModeForm
+			m.ParamsError = ""
+			return m, nil
+		case tea.KeyEnter:
+			return m.commitPresetName()
+		}
+		if keyMsg.String() == "ctrl+c" {
+			return m, tea.Quit
+		}
+	}
+	var cmd tea.Cmd
+	m.PresetNameInput, cmd = m.PresetNameInput.Update(msg)
+	return m, cmd
+}
+
+// commitPresetName validates the typed name and either saves the
+// preset immediately or shifts into the overwrite-confirmation
+// sub-mode when the name already exists for this target.
+func (m Model) commitPresetName() (tea.Model, tea.Cmd) {
+	name := strings.TrimSpace(m.PresetNameInput.Value())
+	if name == "" {
+		m.ParamsError = "preset name cannot be empty"
+		return m, nil
+	}
+	if m.Presets == nil {
+		m.ParamsError = "presets store unavailable"
+		return m, nil
+	}
+	if m.ParamsTarget == nil {
+		// Defensive: shouldn't happen because we entered SaveName from
+		// a valid form.
+		m.ParamsSubMode = paramsSubModeForm
+		return m, nil
+	}
+	target := m.ParamsTarget.Name
+	if m.Presets.Exists(m.MakefilePath, target, name) && name != m.PendingPresetName {
+		// Existing preset with a different original — confirm.
+		m.PendingPresetName = name
+		m.ParamsSubMode = paramsSubModeOverwriteConfirm
+		m.ParamsError = ""
+		return m, nil
+	}
+	return m.savePreset(name)
+}
+
+// updateParamsOverwriteConfirm handles the inline "y/n" prompt that
+// fires when the user typed an already-taken preset name.
+func (m Model) updateParamsOverwriteConfirm(msg tea.Msg) (tea.Model, tea.Cmd) {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+	switch keyMsg.String() {
+	case "y", "Y", "enter":
+		return m.savePreset(m.PendingPresetName)
+	case "n", "N", "esc":
+		// Back to the name prompt so the user can pick a different name.
+		m.ParamsSubMode = paramsSubModeSaveName
+		m.ParamsError = ""
+		return m, nil
+	case "ctrl+c":
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+// savePreset persists the form's current env/flags under name, then
+// returns the user to the form with a brief status message echoed
+// inline.
+func (m Model) savePreset(name string) (tea.Model, tea.Cmd) {
+	if m.Presets == nil || m.ParamsTarget == nil {
+		m.ParamsSubMode = paramsSubModeForm
+		return m, nil
+	}
+	env, err := parseEnvLine(m.ParamsEnvInput.Value())
+	if err != nil {
+		m.ParamsError = err.Error()
+		m.ParamsSubMode = paramsSubModeForm
+		return m, nil
+	}
+	flags, err := parseFlagsLine(m.ParamsFlagsInput.Value())
+	if err != nil {
+		m.ParamsError = err.Error()
+		m.ParamsSubMode = paramsSubModeForm
+		return m, nil
+	}
+
+	m.Presets.Upsert(m.MakefilePath, m.ParamsTarget.Name, presets.Preset{
+		Name:  name,
+		Env:   env,
+		Flags: flags,
+	})
+	if err := m.Presets.Save(); err != nil {
+		m.ParamsError = "failed to save preset: " + err.Error()
+		m.ParamsSubMode = paramsSubModeForm
+		return m, nil
+	}
+
+	m.PendingPresetName = name
+	m.ParamsSubMode = paramsSubModeForm
+	m.ParamsError = "" // clear; success status is shown via a separate field
+	m.PresetsStatus = fmt.Sprintf("Saved preset %q", name)
+	return m, nil
+}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -29,6 +29,8 @@ func (m Model) View() string {
 		return m.renderConfirmView()
 	case StateRunParams:
 		return m.renderRunParamsView()
+	case StateRunPresets:
+		return m.renderRunPresetsView()
 	case StateVariables:
 		return m.renderVariablesView()
 	case StateWorkspace:

--- a/internal/tui/view_params.go
+++ b/internal/tui/view_params.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -33,13 +34,25 @@ func (m Model) renderRunParamsContent(width int) string {
 	title := TitleStyle.Render("Run Parameters")
 	util.WriteString(&builder, title+"\n\n")
 
-	// Target name
+	// Target name + (if any) saved-presets badge so users discover
+	// the Ctrl+P / Ctrl+S workflow without having to read the docs.
 	if m.ParamsTarget != nil {
 		targetInfo := lipgloss.NewStyle().
 			Foreground(PrimaryColor).
 			Bold(true).
 			Render("Target: " + m.ParamsTarget.Name)
-		util.WriteString(&builder, targetInfo+"\n")
+		util.WriteString(&builder, targetInfo)
+
+		if m.Presets != nil {
+			n := m.Presets.Count(m.MakefilePath, m.ParamsTarget.Name)
+			if n > 0 {
+				badge := lipgloss.NewStyle().
+					Foreground(TextMuted).
+					Render(fmt.Sprintf("   %d preset(s) available — Ctrl+P to load", n))
+				util.WriteString(&builder, badge)
+			}
+		}
+		util.WriteString(&builder, "\n")
 
 		if m.ParamsTarget.Description != "" {
 			desc := lipgloss.NewStyle().
@@ -60,6 +73,31 @@ func (m Model) renderRunParamsContent(width int) string {
 		Italic(true).
 		Render("Tip: KEY=value pairs in env, quote values with spaces: MSG=\"hi there\"")
 	util.WriteString(&builder, hint)
+
+	// Inline preset wizard overlay (Ctrl+S → name → optional overwrite).
+	if m.ParamsSubMode == paramsSubModeSaveName {
+		label := lipgloss.NewStyle().
+			Foreground(PrimaryColor).
+			Bold(true).
+			Render("Save as preset:")
+		util.WriteString(&builder, "\n\n"+label+"\n"+m.PresetNameInput.View())
+	}
+	if m.ParamsSubMode == paramsSubModeOverwriteConfirm {
+		confirm := lipgloss.NewStyle().
+			Foreground(WarningColor).
+			Bold(true).
+			Render(fmt.Sprintf("Preset %q already exists. Overwrite? [y/n]", m.PendingPresetName))
+		util.WriteString(&builder, "\n\n"+confirm)
+	}
+
+	// Transient success message after Ctrl+S → save.
+	if m.PresetsStatus != "" && m.ParamsSubMode == paramsSubModeForm {
+		ok := lipgloss.NewStyle().
+			Foreground(SuccessColor).
+			Bold(true).
+			Render("✓ " + m.PresetsStatus)
+		util.WriteString(&builder, "\n\n"+ok)
+	}
 
 	// Inline validation error, if any
 	if m.ParamsError != "" {
@@ -97,7 +135,13 @@ func (m Model) renderRunParamsStatusBar(width int) string {
 	leftBar := lipgloss.JoinHorizontal(lipgloss.Top, pathNugget)
 	leftWidth := lipgloss.Width(leftBar)
 
-	helpText := "enter: run • tab: switch field • esc: cancel • q: quit"
+	helpText := "enter: run • tab: switch field • ctrl+s: save preset • ctrl+p: load preset • esc: cancel"
+	switch m.ParamsSubMode {
+	case paramsSubModeSaveName:
+		helpText = "enter: confirm name • esc: back"
+	case paramsSubModeOverwriteConfirm:
+		helpText = "y: overwrite • n/esc: back"
+	}
 	right := lipgloss.NewStyle().
 		Foreground(TextMuted).
 		Padding(0, 1).

--- a/internal/tui/view_presets.go
+++ b/internal/tui/view_presets.go
@@ -1,0 +1,217 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/rshelekhov/lazymake/internal/presets"
+	"github.com/rshelekhov/lazymake/internal/util"
+)
+
+// renderRunPresetsView draws the saved-presets picker (issue #35).
+// Layout mirrors the graph and params views: full-width content with
+// a rounded border, status bar pinned to the bottom.
+func (m Model) renderRunPresetsView() string {
+	if m.Width == 0 || m.Height == 0 {
+		return "Loading presets..."
+	}
+
+	content := m.renderPresetsContent(m.Width)
+	statusBar := m.renderPresetsStatusBar(m.Width)
+	return lipgloss.JoinVertical(lipgloss.Left, content, statusBar)
+}
+
+// renderPresetsContent renders the bordered list of presets.
+func (m Model) renderPresetsContent(width int) string {
+	var builder strings.Builder
+
+	title := TitleStyle.Render("Saved Presets")
+	util.WriteString(&builder, title+"\n\n")
+
+	if m.PresetsTarget != nil {
+		targetInfo := lipgloss.NewStyle().
+			Foreground(PrimaryColor).
+			Bold(true).
+			Render("Target: " + m.PresetsTarget.Name)
+		util.WriteString(&builder, targetInfo+"\n\n")
+	}
+
+	if len(m.PresetsItems) == 0 {
+		empty := lipgloss.NewStyle().
+			Foreground(TextMuted).
+			Italic(true).
+			Render("No saved presets for this target yet.")
+		hint := lipgloss.NewStyle().
+			Foreground(TextMuted).
+			Render("Press " + lipgloss.NewStyle().Bold(true).Render("e") +
+				" to open the params form, then " +
+				lipgloss.NewStyle().Bold(true).Render("Ctrl+S") +
+				" to save the current values as a preset.")
+		util.WriteString(&builder, empty+"\n\n"+hint+"\n")
+	} else {
+		util.WriteString(&builder, m.renderPresetsRows()+"\n")
+	}
+
+	if m.PresetsSubMode == presetsSubModeDeleteConfirm {
+		confirm := lipgloss.NewStyle().
+			Foreground(WarningColor).
+			Bold(true).
+			Render(fmt.Sprintf("Delete preset %q? [y/n]", m.PresetsPendingDelete))
+		util.WriteString(&builder, "\n"+confirm)
+	}
+
+	if m.PresetsStatus != "" {
+		ok := lipgloss.NewStyle().
+			Foreground(SuccessColor).
+			Bold(true).
+			Render("✓ " + m.PresetsStatus)
+		util.WriteString(&builder, "\n"+ok)
+	}
+	if m.PresetsError != "" {
+		errLine := lipgloss.NewStyle().
+			Foreground(ErrorColor).
+			Bold(true).
+			Render("✗ " + m.PresetsError)
+		util.WriteString(&builder, "\n"+errLine)
+	}
+
+	containerStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(BorderColor).
+		Padding(1, 2).
+		Width(width - 2)
+	return containerStyle.Render(builder.String())
+}
+
+// renderPresetsRows lays out one row per preset. The currently
+// last-used preset is marked with ★ so users can pick it out without
+// memorizing names.
+func (m Model) renderPresetsRows() string {
+	var builder strings.Builder
+
+	cursorStyle := lipgloss.NewStyle().Foreground(PrimaryColor).Bold(true)
+	nameStyle := lipgloss.NewStyle().Foreground(TextPrimary).Bold(true)
+	mutedStyle := lipgloss.NewStyle().Foreground(TextMuted)
+	starStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FFD700"))
+
+	maxNameLen := 0
+	for _, p := range m.PresetsItems {
+		if l := len(p.Name); l > maxNameLen {
+			maxNameLen = l
+		}
+	}
+
+	lastUsedName := ""
+	if m.Presets != nil && m.PresetsTarget != nil {
+		if lu, ok := m.Presets.LastUsed(m.MakefilePath, m.PresetsTarget.Name); ok {
+			lastUsedName = lu.Name
+		}
+	}
+
+	for i, p := range m.PresetsItems {
+		// Cursor marker
+		marker := "  "
+		if i == m.PresetsCursor {
+			marker = cursorStyle.Render("▶ ")
+		}
+
+		// ★ for the last-used preset, blank space otherwise to keep
+		// the columns aligned.
+		star := "  "
+		if p.Name == lastUsedName {
+			star = starStyle.Render("★ ")
+		}
+
+		// Name column (padded to align summaries).
+		name := nameStyle.Render(p.Name)
+		padding := strings.Repeat(" ", maxNameLen-len(p.Name)+2)
+
+		// Summary: env (key count) + flags (joined).
+		summary := summarizePreset(p)
+
+		util.WriteString(&builder, marker+star+name+padding+mutedStyle.Render(summary)+"\n")
+	}
+	return builder.String()
+}
+
+// summarizePreset returns a one-line description of a preset's
+// payload: K env vars, the joined flags, and a relative "updated"
+// timestamp. Kept compact so the picker fits comfortably on 80-col
+// terminals.
+func summarizePreset(p presets.Preset) string {
+	parts := []string{}
+	if n := len(p.Env); n > 0 {
+		parts = append(parts, fmt.Sprintf("env:%d", n))
+	}
+	if len(p.Flags) > 0 {
+		parts = append(parts, "flags: "+strings.Join(p.Flags, " "))
+	}
+	if len(parts) == 0 {
+		parts = append(parts, "no params")
+	}
+	if !p.UpdatedAt.IsZero() {
+		parts = append(parts, "updated "+humanizeTime(p.UpdatedAt))
+	}
+	return strings.Join(parts, "  •  ")
+}
+
+// humanizeTime formats t relative to now, e.g. "2m ago", "3d ago",
+// falling back to an ISO date for distant timestamps so the picker
+// stays useful long-term.
+func humanizeTime(t time.Time) string {
+	delta := time.Since(t)
+	switch {
+	case delta < time.Minute:
+		return "just now"
+	case delta < time.Hour:
+		return fmt.Sprintf("%dm ago", int(delta.Minutes()))
+	case delta < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(delta.Hours()))
+	case delta < 30*24*time.Hour:
+		return fmt.Sprintf("%dd ago", int(delta.Hours()/24))
+	default:
+		return t.Format("2006-01-02")
+	}
+}
+
+// renderPresetsStatusBar mirrors the params/graph views: workspace
+// nugget on the left, contextual help on the right.
+func (m Model) renderPresetsStatusBar(width int) string {
+	statusBarStyle := lipgloss.NewStyle().Foreground(TextPrimary)
+
+	coloredNuggetStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.AdaptiveColor{Light: "#FFFFFF", Dark: "#000000"}).
+		Background(PrimaryColor).
+		Padding(0, 1).
+		MarginRight(1)
+
+	workspacePath := m.getWorkspaceDisplayPath()
+	pathNugget := coloredNuggetStyle.Render(workspacePath)
+
+	leftBar := lipgloss.JoinHorizontal(lipgloss.Top, pathNugget)
+	leftWidth := lipgloss.Width(leftBar)
+
+	helpText := "enter: run • e: edit • d: delete • esc: cancel • q: quit"
+	if m.PresetsSubMode == presetsSubModeDeleteConfirm {
+		helpText = "y: confirm • n/esc: cancel • q: quit"
+	}
+	right := lipgloss.NewStyle().
+		Foreground(TextMuted).
+		Padding(0, 1).
+		Render(helpText)
+	rightWidth := lipgloss.Width(right)
+
+	middleWidth := max(width-2-leftWidth-rightWidth, 1)
+	middle := lipgloss.NewStyle().
+		Width(middleWidth).
+		Align(lipgloss.Left).
+		Render("")
+
+	bar := lipgloss.JoinHorizontal(lipgloss.Top, leftBar, middle, right)
+	return statusBarStyle.
+		Width(width).
+		Padding(1, 1).
+		Render(bar)
+}


### PR DESCRIPTION
Closes #35.

Adds named run presets so users can save `(env, flags)` configurations per target and reuse them across sessions. Builds on the interactive parameters form from #37.

## What's new

**`internal/presets`** — new package, on-disk store at `~/.cache/lazymake/presets.json`.
- Per-`(makefile, target)` buckets with a `LastUsedPreset` pointer (O(1) lookup for `R: rerun`).
- Atomic save via `tmp + rename` — no half-written files on crash.
- Graceful degradation: corrupt or missing JSON yields an empty manager, the TUI keeps running.

**TUI integration**
- `p` in the list → opens `StateRunPresets` picker (★ marks the last-used preset, `e` edits, `d` deletes with y/n confirm).
- `Enter` on a preset row → runs the target through the same `StateConfirmDangerous` gate as quick-Enter; critical targets still get the safety dialog.
- `R` in the list → reruns the last-used preset for the cursor target (no-op when none).
- Inside the params form (#37):
  - `Ctrl+S` → save current env/flags under a typed name; collision triggers an inline overwrite-confirm prompt.
  - `Ctrl+P` → open the picker with return-to-form semantics so `Enter` populates the inputs and keeps the user in the form.
- Presets for renamed/removed targets stay in the JSON file but never surface in the UI — the picker is keyed off the current list cursor.

## Acceptance criteria
- [x] Presets stored per Makefile and target — `Entries[absMakefilePath][targetName]`.
- [x] Create / select / update / delete — `Ctrl+S` (create/update) + picker (`Enter`/`d`/`e`).
- [x] Last-used easy to reuse — `R` hotkey + ★ marker.
- [x] Presets survive restart — `Save()` on every mutation, `Load()` at startup.
- [x] Missing/renamed targets handled gracefully — hidden in UI, kept in JSON.

## Tests
- `internal/presets/presets_test.go` — round-trip, upsert-vs-update, delete-clears-last-used, list-sort, corrupt-JSON recovery, atomic save.
- `internal/tui/presets_test.go` — picker open/Enter/Esc/delete/cancel-delete, save-from-form, overwrite-yes/no, validate-first, load-from-form (`Ctrl+P`), `R`-rerun + no-op, missing-target-hidden, nil-manager-no-crash.
- `internal/tui/params_test.go` — `formatEnvRaw` / `formatFlagsRaw` round-trip through `parseEnvLine`.

## Notes
- Storage lives next to `history.json` in `~/.cache/lazymake/` — kept compatible with #12 (preset import/export for team sharing), which can later layer project-local presets on top without migrating this path.
- `SwitchWorkspace` preserves the manager across Makefile switches.